### PR TITLE
Fixing errors with OpenSSL 1.0/1.1

### DIFF
--- a/.github/workflows/postgresql-16-src-make-ssl11.yml
+++ b/.github/workflows/postgresql-16-src-make-ssl11.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Build postgres
         run: |
-          ./configure --with-openssl  --enable-tap-tests=no
+          ./configure --with-openssl  --enable-tap-tests=no --enable-cassert
           make -j
           sudo make install
         working-directory: src

--- a/.github/workflows/postgresql-16-src-make-ssl11.yml
+++ b/.github/workflows/postgresql-16-src-make-ssl11.yml
@@ -1,0 +1,92 @@
+name: postgresql-16-src-make-ssl11
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    name: pg-16-src-make-test-ssl11
+    runs-on: ubuntu-20.04
+    steps:
+
+
+      - name: Remove old postgres
+        run: |
+          sudo apt purge postgresql-client-common postgresql-common \
+            postgresql postgresql*
+          sudo rm -rf /var/lib/postgresql /var/log/postgresql /etc/postgresql \
+           /usr/lib/postgresql /usr/include/postgresql /usr/share/postgresql \
+           /etc/postgresql
+          sudo rm -f /usr/bin/pg_config
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libreadline6-dev systemtap-sdt-dev \
+            zlib1g-dev libssl-dev libpam0g-dev bison flex \
+            libipc-run-perl -y docbook-xsl docbook-xsl libxml2 libxml2-utils \
+            libxml2-dev libxslt-dev xsltproc libkrb5-dev libldap2-dev \
+            libsystemd-dev gettext tcl-dev libperl-dev pkg-config \
+            libselinux1-dev python3-dev \
+            uuid-dev liblz4-dev libjson-c-dev libcurl4-openssl-dev
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
+
+      - name: Clone postgres repository
+        uses: actions/checkout@v2
+        with:
+          repository: 'postgres/postgres'
+          ref: 'a81e5516fa4bc53e332cb35eefe231147c0e1749'
+          path: 'src'
+
+      - name: Clone postgres-tde-ext repository
+        uses: actions/checkout@v2
+        with:
+          path: 'src/contrib/postgres-tde-ext'
+
+      - name: Create pgsql dir
+        run: mkdir -p /opt/pgsql
+
+      - name: Build postgres
+        run: |
+          ./configure --with-openssl  --enable-tap-tests=no
+          make -j
+          sudo make install
+        working-directory: src
+
+      - name: Build postgres-tde-ext
+        run: |
+          ./configure
+          make -j
+          sudo make install
+        working-directory: src/contrib/postgres-tde-ext
+
+      - name: Start postgresql cluster with pg_tde
+        run: |
+          export PATH="/usr/local/pgsql/bin:$PATH"
+          sudo cp /usr/local/pgsql/bin/pg_config /usr/bin
+          initdb -D /opt/pgsql/data
+          echo "shared_preload_libraries = 'pg_tde'" >> \
+            /opt/pgsql/data/postgresql.conf
+          echo "pg_tde.keyringConfigFile = '/tmp/keyring.json'" >> \
+            /opt/pgsql/data/postgresql.conf
+          cp src/contrib/postgres-tde-ext/keyring.json /tmp/keyring.json
+          pg_ctl -D /opt/pgsql/data -l logfile start
+
+      - name: Test postgres-tde-ext
+        run: |
+          make installcheck
+        working-directory: src/contrib/postgres-tde-ext
+
+      - name: Report on test fail
+        uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: Regressions diff and postgresql log
+          path: |
+            src/contrib/postgres-tde-ext/regression.diffs
+            logfile
+          retention-days: 3
+
+      - name: Report on test fail 2
+        if: ${{ failure() }}
+        run: |
+          cat src/contrib/postgres-tde-ext/regression.diffs

--- a/.github/workflows/postgresql-16-src-make.yml
+++ b/.github/workflows/postgresql-16-src-make.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Build postgres
         run: |
-          ./configure --with-openssl  --enable-tap-tests=no
+          ./configure --with-openssl  --enable-tap-tests=no --enable-cassert
           make -j
           sudo make install
         working-directory: src

--- a/src/encryption/enc_aes.c
+++ b/src/encryption/enc_aes.c
@@ -107,9 +107,6 @@ static void AesRun(int enc, const unsigned char* key, const unsigned char* iv, c
 	ctx = EVP_CIPHER_CTX_new();
 	EVP_CIPHER_CTX_init(ctx);
 
-	EVP_CIPHER_CTX_set_padding(ctx, 0);
-	Assert(in_len % cipher_block_size == 0);
-
 	if(EVP_CipherInit_ex(ctx, cipher, NULL, key, iv, enc) == 0)
 	{
 		#ifdef FRONTEND
@@ -120,6 +117,9 @@ static void AesRun(int enc, const unsigned char* key, const unsigned char* iv, c
 		#endif
 		goto cleanup;
 	}
+
+	EVP_CIPHER_CTX_set_padding(ctx, 0);
+	Assert(in_len % cipher_block_size == 0);
 
 
 	if(EVP_CipherUpdate(ctx, out, out_len, in, in_len) == 0)

--- a/src/encryption/enc_aes.c
+++ b/src/encryption/enc_aes.c
@@ -121,7 +121,6 @@ static void AesRun(int enc, const unsigned char* key, const unsigned char* iv, c
 	EVP_CIPHER_CTX_set_padding(ctx, 0);
 	Assert(in_len % cipher_block_size == 0);
 
-
 	if(EVP_CipherUpdate(ctx, out, out_len, in, in_len) == 0)
 	{
 		#ifdef FRONTEND
@@ -144,8 +143,9 @@ static void AesRun(int enc, const unsigned char* key, const unsigned char* iv, c
 		goto cleanup;
 	}
 
-	// We encrypt one block (16 bytes)
-	// Our expectation is that the result should also be 16 bytes, without any additional padding
+	/* We encrypt one block (16 bytes)
+	 * Our expectation is that the result should also be 16 bytes, without any additional padding
+	 */
 	*out_len += out_len2;
 	Assert(in_len == *out_len);
 

--- a/src/encryption/enc_aes.c
+++ b/src/encryption/enc_aes.c
@@ -73,8 +73,6 @@ AesRun2(EVP_CIPHER_CTX** ctxPtr, int enc, const unsigned char* key, const unsign
 		*ctxPtr = EVP_CIPHER_CTX_new();
 		EVP_CIPHER_CTX_init(*ctxPtr);
 		
-		EVP_CIPHER_CTX_set_padding(*ctxPtr, 0);
-
 		if(EVP_CipherInit_ex(*ctxPtr, cipher2, NULL, key, iv, enc) == 0)
 		{
 			#ifdef FRONTEND
@@ -86,6 +84,8 @@ AesRun2(EVP_CIPHER_CTX** ctxPtr, int enc, const unsigned char* key, const unsign
 
 			return;
 		}
+
+		EVP_CIPHER_CTX_set_padding(*ctxPtr, 0);
 	}
 
 	if(EVP_CipherUpdate(*ctxPtr, out, out_len, in, in_len) == 0)


### PR DESCRIPTION
Issue: there's a slight behavior difference between OpenSSL 1.1 and 3.0 in regards to padding, and how the EVP encryption/decryption functions exactly behave.

Our code also incorrectly used these functions until now, which by chance worked correctly with 3.0, but caused decryption issues with 1.0/1.1.

This commit:

* Fixes the issue
* Adds a few related assertions
* Adds an Ubuntu 20.04 (OpenSSL 1.1) github runner to verify that everything works correctly with 1.1.