### PR TITLE
Updated dockerhub repo name

### DIFF
--- a/.github/workflows/docker-push-tde-image.yaml
+++ b/.github/workflows/docker-push-tde-image.yaml
@@ -21,5 +21,5 @@ jobs:
 
     - name: Build and push Docker image
       run: |
-        docker build -t perconalab/pg_tde:${{ github.sha }} -t perconalab/pg_tde:latest . -f docker/Dockerfile
-        docker push -a perconalab/pg_tde
+        docker build -t perconalab/postgres-tde-ext:${{ github.sha }} -t perconalab/postgres-tde-ext:latest . -f docker/Dockerfile
+        docker push -a perconalab/postgres-tde-ext

--- a/.github/workflows/docker-test-image.yaml
+++ b/.github/workflows/docker-test-image.yaml
@@ -12,7 +12,7 @@ jobs:
 
     - name: Build Docker image
       run: |
-        docker build -t perconalab/pg_tde:${{ github.sha }} -t pg_tde-test . -f docker/Dockerfile
+        docker build -t perconalab/postgres-tde-ext:${{ github.sha }} -t pg_tde-test . -f docker/Dockerfile
 
     - name: Run and test Docker image
       run: |

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ sudo dpkg -i pgtde-pgdg16.deb
 
 ## Run in Docker
 
-You can find docker images built from the current main branch on [Docker Hub](https://hub.docker.com/r/perconalab/pg_tde). Images build on top of [postgres:16](https://hub.docker.com/_/postgres) official image. To run it:
+You can find docker images built from the current main branch on [Docker Hub](https://hub.docker.com/r/perconalab/postgres-tde-ext). Images build on top of [postgres:16](https://hub.docker.com/_/postgres) official image. To run it:
 ```
-docker run --name pg-tde -e POSTGRES_PASSWORD=mysecretpassword -d perconalab/pg_tde
+docker run --name pg-tde -e POSTGRES_PASSWORD=mysecretpassword -d perconalab/postgres-tde-ext
 ```
 It builds and adds `pg_tde` extension to Postgres 16. Relevant `postgresql.conf` and `tde_conf.json` are created in `/etc/postgresql/` inside the container. This dir is exposed as volume.
 

--- a/documentation/docs/install.md
+++ b/documentation/docs/install.md
@@ -61,13 +61,13 @@ Install `pg_tde` using one of available installation methods:
 
 === "Run in Docker"
 
-    You can find Docker images built from the current main branch on [Docker Hub](https://hub.docker.com/r/perconalab/pg_tde). Images are built on top of [postgres:16](https://hub.docker.com/_/postgres) official image.     
+    You can find Docker images built from the current main branch on [Docker Hub](https://hub.docker.com/r/perconalab/postgres-tde-ext). Images are built on top of [postgres:16](https://hub.docker.com/_/postgres) official image.
 
     To run `pg_tde` in Docker, use the following command:    
 
     ```
-    docker run --name pg-tde -e POSTGRES_PASSWORD=mysecretpassword -d perconalab/pg_tde
-    ```    
+    docker run --name pg-tde -e POSTGRES_PASSWORD=mysecretpassword -d perconalab/postgres-tde-ext
+    ```
 
     It builds and adds `pg_tde` extension to PostgreSQL 16. Relevant `postgresql.conf` and `tde_conf.json` are created in `/etc/postgresql/` inside the container. This directory is exposed as a volume.    
 


### PR DESCRIPTION
This PR renames the dockerhub repository name from `perconalab/pg_tde` to `perconalab/postgres-tde-ext` to align with the repository rename.

I'm not sure if this PR is necessarily that useful for you, maybe you prefer to do this yourself :) OR this might do too much since it also practically re-enables the github action that pushes image builds from `main` to dockerhub, which seems to have not worked for a while due to wrong repo name.

Fixes #130