### PR TITLE
Disallow deletion of keyring used by Master key.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -15,6 +15,7 @@ pgtde_is_encrypted \
 multi_insert \
 trigger_on_view \
 insert_update_delete \
+keyprovider_dependency \
 vault_v2_test
 TAP_TESTS = 1
 

--- a/expected/keyprovider_dependency.out
+++ b/expected/keyprovider_dependency.out
@@ -1,0 +1,33 @@
+CREATE EXTENSION pg_tde;
+SELECT pg_tde_add_key_provider_file('mk-file-valut','/tmp/pg_tde_test_keyring.per');
+ pg_tde_add_key_provider_file 
+------------------------------
+                            1
+(1 row)
+
+SELECT pg_tde_add_key_provider_file('free-file-valut','/tmp/pg_tde_test_keyring_2.per');
+ pg_tde_add_key_provider_file 
+------------------------------
+                            2
+(1 row)
+
+SELECT pg_tde_add_key_provider_vault_v2('V2-Wallet','vault-token','percona.com/vault-v2/percona','/mount/dev','ca-cert-auth');
+ pg_tde_add_key_provider_vault_v2 
+----------------------------------
+                                3
+(1 row)
+
+SELECT pg_tde_set_master_key('test-db-master-key','mk-file-valut');
+ pg_tde_set_master_key 
+-----------------------
+ 
+(1 row)
+
+-- Try dropping the in-use key provider
+DELETE FROM percona_tde.pg_tde_key_provider WHERE provider_name = 'mk-file-valut'; -- Should fail
+ERROR:  Key provider "mk-file-valut" cannot be deleted
+DETAIL:  The master key for the database depends on this key provider.
+-- Now delete the un-used  key provider
+DELETE FROM percona_tde.pg_tde_key_provider WHERE provider_name = 'free-file-valut'; -- Should pass
+DELETE FROM percona_tde.pg_tde_key_provider WHERE provider_name = 'V2-Wallet'; -- Should pass
+DROP EXTENSION pg_tde;

--- a/expected/keyprovider_dependency.out
+++ b/expected/keyprovider_dependency.out
@@ -1,33 +1,33 @@
 CREATE EXTENSION pg_tde;
-SELECT pg_tde_add_key_provider_file('mk-file-valut','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_key_provider_file('mk-file','/tmp/pg_tde_test_keyring.per');
  pg_tde_add_key_provider_file 
 ------------------------------
                             1
 (1 row)
 
-SELECT pg_tde_add_key_provider_file('free-file-valut','/tmp/pg_tde_test_keyring_2.per');
+SELECT pg_tde_add_key_provider_file('free-file','/tmp/pg_tde_test_keyring_2.per');
  pg_tde_add_key_provider_file 
 ------------------------------
                             2
 (1 row)
 
-SELECT pg_tde_add_key_provider_vault_v2('V2-Wallet','vault-token','percona.com/vault-v2/percona','/mount/dev','ca-cert-auth');
+SELECT pg_tde_add_key_provider_vault_v2('V2-vault','vault-token','percona.com/vault-v2/percona','/mount/dev','ca-cert-auth');
  pg_tde_add_key_provider_vault_v2 
 ----------------------------------
                                 3
 (1 row)
 
-SELECT pg_tde_set_master_key('test-db-master-key','mk-file-valut');
+SELECT pg_tde_set_master_key('test-db-master-key','mk-file');
  pg_tde_set_master_key 
 -----------------------
  
 (1 row)
 
 -- Try dropping the in-use key provider
-DELETE FROM percona_tde.pg_tde_key_provider WHERE provider_name = 'mk-file-valut'; -- Should fail
-ERROR:  Key provider "mk-file-valut" cannot be deleted
+DELETE FROM percona_tde.pg_tde_key_provider WHERE provider_name = 'mk-file'; -- Should fail
+ERROR:  Key provider "mk-file" cannot be deleted
 DETAIL:  The master key for the database depends on this key provider.
 -- Now delete the un-used  key provider
-DELETE FROM percona_tde.pg_tde_key_provider WHERE provider_name = 'free-file-valut'; -- Should pass
-DELETE FROM percona_tde.pg_tde_key_provider WHERE provider_name = 'V2-Wallet'; -- Should pass
+DELETE FROM percona_tde.pg_tde_key_provider WHERE provider_name = 'free-file'; -- Should pass
+DELETE FROM percona_tde.pg_tde_key_provider WHERE provider_name = 'V2-vault'; -- Should pass
 DROP EXTENSION pg_tde;

--- a/meson.build
+++ b/meson.build
@@ -73,6 +73,7 @@ tests += {
       'update_compare_indexes',
       'pgtde_is_encrypted',
       'multi_insert',
+      'keyprovider_dependency',
       'trigger_on_view',
       'insert_update_delete',
       'vault_v2_test',

--- a/pg_tde--1.0.sql
+++ b/pg_tde--1.0.sql
@@ -16,6 +16,18 @@ CREATE TABLE percona_tde.pg_tde_key_provider(provider_id SERIAL,
 -- in include/catalog/tde_keyring.h and src/catalog/tde_keyring.c files.
 
 SELECT pg_catalog.pg_extension_config_dump('percona_tde.pg_tde_key_provider', '');
+
+-- Trigger function to check master key dependency on key provider row
+CREATE FUNCTION keyring_delete_dependency_check_trigger()
+RETURNS TRIGGER
+AS 'MODULE_PATHNAME'
+LANGUAGE C;
+
+CREATE TRIGGER pg_tde_key_provider_delete_dependency_check_trigger
+BEFORE DELETE ON percona_tde.pg_tde_key_provider
+FOR EACH ROW
+EXECUTE FUNCTION keyring_delete_dependency_check_trigger();
+
 -- Key Provider Management
 
 CREATE OR REPLACE FUNCTION pg_tde_add_key_provider(provider_type VARCHAR(10), provider_name VARCHAR(128), options JSON)

--- a/sql/keyprovider_dependency.sql
+++ b/sql/keyprovider_dependency.sql
@@ -1,0 +1,15 @@
+CREATE EXTENSION pg_tde;
+
+SELECT pg_tde_add_key_provider_file('mk-file-valut','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_key_provider_file('free-file-valut','/tmp/pg_tde_test_keyring_2.per');
+SELECT pg_tde_add_key_provider_vault_v2('V2-Wallet','vault-token','percona.com/vault-v2/percona','/mount/dev','ca-cert-auth');
+
+SELECT pg_tde_set_master_key('test-db-master-key','mk-file-valut');
+
+-- Try dropping the in-use key provider
+DELETE FROM percona_tde.pg_tde_key_provider WHERE provider_name = 'mk-file-valut'; -- Should fail
+-- Now delete the un-used  key provider
+DELETE FROM percona_tde.pg_tde_key_provider WHERE provider_name = 'free-file-valut'; -- Should pass
+DELETE FROM percona_tde.pg_tde_key_provider WHERE provider_name = 'V2-Wallet'; -- Should pass
+
+DROP EXTENSION pg_tde;

--- a/sql/keyprovider_dependency.sql
+++ b/sql/keyprovider_dependency.sql
@@ -1,15 +1,15 @@
 CREATE EXTENSION pg_tde;
 
-SELECT pg_tde_add_key_provider_file('mk-file-valut','/tmp/pg_tde_test_keyring.per');
-SELECT pg_tde_add_key_provider_file('free-file-valut','/tmp/pg_tde_test_keyring_2.per');
-SELECT pg_tde_add_key_provider_vault_v2('V2-Wallet','vault-token','percona.com/vault-v2/percona','/mount/dev','ca-cert-auth');
+SELECT pg_tde_add_key_provider_file('mk-file','/tmp/pg_tde_test_keyring.per');
+SELECT pg_tde_add_key_provider_file('free-file','/tmp/pg_tde_test_keyring_2.per');
+SELECT pg_tde_add_key_provider_vault_v2('V2-vault','vault-token','percona.com/vault-v2/percona','/mount/dev','ca-cert-auth');
 
-SELECT pg_tde_set_master_key('test-db-master-key','mk-file-valut');
+SELECT pg_tde_set_master_key('test-db-master-key','mk-file');
 
 -- Try dropping the in-use key provider
-DELETE FROM percona_tde.pg_tde_key_provider WHERE provider_name = 'mk-file-valut'; -- Should fail
+DELETE FROM percona_tde.pg_tde_key_provider WHERE provider_name = 'mk-file'; -- Should fail
 -- Now delete the un-used  key provider
-DELETE FROM percona_tde.pg_tde_key_provider WHERE provider_name = 'free-file-valut'; -- Should pass
-DELETE FROM percona_tde.pg_tde_key_provider WHERE provider_name = 'V2-Wallet'; -- Should pass
+DELETE FROM percona_tde.pg_tde_key_provider WHERE provider_name = 'free-file'; -- Should pass
+DELETE FROM percona_tde.pg_tde_key_provider WHERE provider_name = 'V2-vault'; -- Should pass
 
 DROP EXTENSION pg_tde;

--- a/src/catalog/tde_master_key.c
+++ b/src/catalog/tde_master_key.c
@@ -445,6 +445,31 @@ SetMasterKey(const char *key_name, const char *provider_name)
 }
 
 /*
+ * Returns the provider ID of the keyring that holds the master key
+ * Return InvalidOid if the master key is not set for the database
+ */
+Oid
+GetMasterKeyProviderId(void)
+{
+    TDEMasterKey *masterKey = NULL;
+    TDEMasterKeyInfo *masterKeyInfo = NULL;
+    Oid keyringId = InvalidOid;
+
+    masterKey = get_master_key_from_cache(true);
+    if (masterKey)
+        return masterKey->keyringId;
+
+    /* Master key not present in cache. Try Loading it from the info file */
+    masterKeyInfo = get_master_key_info();
+    if (masterKeyInfo)
+    {
+        keyringId = masterKeyInfo->keyringId;
+        pfree(masterKeyInfo);
+    }
+    return keyringId;
+}
+
+/*
  * ------------------------------
  * Master key cache realted stuff
  */

--- a/src/include/catalog/tde_master_key.h
+++ b/src/include/catalog/tde_master_key.h
@@ -42,6 +42,7 @@ typedef struct TDEMasterKeyInfo
 
 extern void InitializeMasterKeyInfo(void);
 extern TDEMasterKey* GetMasterKey(void);
-TDEMasterKey* SetMasterKey(const char* key_name, const char* provider_name);
+extern TDEMasterKey* SetMasterKey(const char* key_name, const char* provider_name);
+extern Oid GetMasterKeyProviderId(void);
 
 #endif /*TDE_MASTER_KEY_H*/


### PR DESCRIPTION
The commit adds the before-delete trigger on the keyring catalog to ensure that the key provider used by the master key should not get deleted.