### PR TITLE
Fix internal key XLogging for keyring changes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -32,6 +32,7 @@ src/access/pg_tde_visibilitymap.o \
 src/access/pg_tde_rewrite.o \
 src/access/pg_tdeam_handler.o \
 src/access/pg_tde_ddl.o \
+src/access/pg_tde_xlog.o \
 src/transam/pg_tde_xact_handler.o \
 src/keyring/keyring_config.o \
 src/keyring/keyring_file.o \

--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,7 @@ pg_tde_sources = files(
         'src/access/pg_tde_vacuumlazy.c',
         'src/access/pg_tde_visibilitymap.c',
         'src/access/pg_tde_ddl.c',
+        'src/access/pg_tde_xlog.c',
 
         'src/encryption/enc_tde.c',
         'src/encryption/enc_aes.c',

--- a/src/access/pg_tde_xlog.c
+++ b/src/access/pg_tde_xlog.c
@@ -1,0 +1,78 @@
+/*-------------------------------------------------------------------------
+ *
+ * pg_tde_xlog.c
+ *	  TDE XLog resource namager
+ *
+ *
+ * IDENTIFICATION
+ *	  src/access/pg_tde_xlog.c
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#include "access/xlog.h"
+#include "access/xlog_internal.h"
+#include "access/xloginsert.h"
+
+#include "access/pg_tde_tdemap.h"
+#include "access/pg_tde_xlog.h"
+#include "catalog/tde_master_key.h"
+
+/*
+ * TDE fork XLog
+ */
+void
+pg_tde_rmgr_redo(XLogReaderState *record)
+{
+	uint8		info = XLogRecGetInfo(record) & ~XLR_INFO_MASK;
+
+	if (info == XLOG_TDE_ADD_RELATION_KEY)
+	{
+		XLogRelKey *xlrec = (XLogRelKey *) XLogRecGetData(record);
+
+		pg_tde_write_key_map_entry(&xlrec->rlocator, &xlrec->relKey, false);
+	}
+	else if (info == XLOG_TDE_ADD_MASTER_KEY)
+	{
+		TDEMasterKeyInfo *mkey = (TDEMasterKeyInfo *) XLogRecGetData(record);
+
+		save_master_key_info(mkey);
+	}
+	else
+	{
+		elog(PANIC, "pg_tde_redo: unknown op code %u", info);
+	}
+}
+
+void
+pg_tde_rmgr_desc(StringInfo buf, XLogReaderState *record)
+{
+	uint8		info = XLogRecGetInfo(record) & ~XLR_INFO_MASK;
+
+	if (info == XLOG_TDE_ADD_RELATION_KEY)
+	{
+		XLogRelKey *xlrec = (XLogRelKey *) XLogRecGetData(record);
+
+		appendStringInfo(buf, "add tde internal key for relation %u/%u", xlrec->rlocator.dbOid, xlrec->rlocator.relNumber);
+	}
+	if (info == XLOG_TDE_ADD_MASTER_KEY)
+	{
+		TDEMasterKeyInfo *xlrec = (TDEMasterKeyInfo *) XLogRecGetData(record);
+
+		appendStringInfo(buf, "add tde master key for db %u/%u", xlrec->databaseId, xlrec->tablespaceId);
+	}
+}
+
+const char *
+pg_tde_rmgr_identify(uint8 info)
+{
+	if ((info & ~XLR_INFO_MASK) == XLOG_TDE_ADD_RELATION_KEY)
+		return "XLOG_TDE_ADD_RELATION_KEY";
+
+	if ((info & ~XLR_INFO_MASK) == XLOG_TDE_ADD_MASTER_KEY)
+		return "XLOG_TDE_ADD_MASTER_KEY";
+
+	return NULL;
+}

--- a/src/catalog/tde_master_key.c
+++ b/src/catalog/tde_master_key.c
@@ -10,6 +10,8 @@
  *-------------------------------------------------------------------------
  */
 #include "postgres.h"
+#include "access/xlog.h"
+#include "access/xloginsert.h"
 #include "catalog/tde_master_key.h"
 #include "common/pg_tde_shmem.h"
 #include "storage/lwlock.h"
@@ -22,6 +24,7 @@
 #include "funcapi.h"
 #include "utils/builtins.h"
 #include "pg_tde.h"
+#include "access/pg_tde_xlog.h"
 #include <sys/time.h>
 
 #define PG_TDE_MASTER_KEY_FILENAME "tde_master_key.info"
@@ -55,7 +58,7 @@ static dshash_parameters master_key_dsh_params = {
 
 TdeMasterKeylocalState masterKeyLocalState;
 
-static char *get_master_key_info_path(void);
+static char *get_master_key_info_path(TDEMasterKeyInfo *masterKeyInfo);
 static void master_key_info_attach_shmem(void);
 static Size initialize_shared_state(void *start_address);
 static void initialize_objects_in_dsa_area(dsa_area *dsa, void *raw_dsa_area);
@@ -65,7 +68,7 @@ static int  required_locks_count(void);
 static void shared_memory_shutdown(int code, Datum arg);
 static void master_key_startup_cleanup(int tde_tbl_count, void *arg);
 
-static TDEMasterKeyInfo *save_master_key_info(TDEMasterKey *master_key, GenericKeyring *keyring);
+static TDEMasterKeyInfo *create_master_key_info(TDEMasterKey *master_key, GenericKeyring *keyring);
 static TDEMasterKeyInfo *get_master_key_info(void);
 static inline dshash_table *get_master_key_Hash(void);
 static TDEMasterKey *get_master_key_from_cache(bool acquire_lock);
@@ -182,56 +185,70 @@ shared_memory_shutdown(int code, Datum arg)
 }
 
 static inline char *
-get_master_key_info_path(void)
+get_master_key_info_path(TDEMasterKeyInfo *masterKeyInfo)
 {
     if (*master_key_info_path == 0)
     {
+        Oid db = masterKeyInfo != NULL ? masterKeyInfo->databaseId : MyDatabaseId;
+        Oid spc = masterKeyInfo != NULL ? masterKeyInfo->tablespaceId : MyDatabaseTableSpace;
+
         snprintf(master_key_info_path, MAXPGPATH, "%s/%s",
-                 GetDatabasePath(MyDatabaseId, MyDatabaseTableSpace),
+                 GetDatabasePath(db, spc),
                  PG_TDE_MASTER_KEY_FILENAME);
     }
     return master_key_info_path;
 }
 
+
 static TDEMasterKeyInfo *
-save_master_key_info(TDEMasterKey *master_key, GenericKeyring *keyring)
+create_master_key_info(TDEMasterKey *master_key, GenericKeyring *keyring)
 {
     TDEMasterKeyInfo *masterKeyInfo = NULL;
-    File master_key_file = -1;
-    off_t bytes_written = 0;
-    char *info_file_path = get_master_key_info_path();
 
     Assert(master_key != NULL);
     Assert(keyring != NULL);
 
+// TODO: where to palloc?
     masterKeyInfo = palloc(sizeof(TDEMasterKeyInfo));
-    masterKeyInfo->keyId = keyring->key_id;
     masterKeyInfo->databaseId = MyDatabaseId;
-    masterKeyInfo->keyVersion = 1;
+    masterKeyInfo->tablespaceId = MyDatabaseTableSpace;
+    masterKeyInfo->keyId.version = 1;
     gettimeofday(&masterKeyInfo->creationTime, NULL);
-    strncpy(masterKeyInfo->keyName, master_key->keyName, MASTER_KEY_NAME_LEN);
+    strncpy(masterKeyInfo->keyId.name, master_key->keyId.name, MASTER_KEY_NAME_LEN);
     masterKeyInfo->keyringId = keyring->key_id;
+
+    return masterKeyInfo;
+}
+
+void
+save_master_key_info(TDEMasterKeyInfo *masterKeyInfo)
+{
+    File master_key_file = -1;
+    off_t bytes_written = 0;
+    char *info_file_path = get_master_key_info_path(masterKeyInfo);
 
     master_key_file = PathNameOpenFile(info_file_path, O_CREAT | O_EXCL | O_RDWR | PG_BINARY);
     if (master_key_file < 0)
     {
-        pfree(masterKeyInfo);
-        return NULL;
+        ereport(FATAL,
+            (errcode_for_file_access(),
+                errmsg("Could not open master key info file \"%s\": %m",
+                    info_file_path)));
     }
+
     bytes_written = FileWrite(master_key_file, masterKeyInfo, sizeof(TDEMasterKeyInfo), 0, WAIT_EVENT_DATA_FILE_WRITE);
     if (bytes_written != sizeof(TDEMasterKeyInfo))
     {
-        pfree(masterKeyInfo);
         FileClose(master_key_file);
         /* TODO: delete the invalid file */
         ereport(FATAL,
                 (errcode_for_file_access(),
                  errmsg("TDE master key info file \"%s\" can't be written: %m",
                         info_file_path)));
-        return NULL;
     }
     FileClose(master_key_file);
-    return masterKeyInfo;
+
+
 }
 
 /*
@@ -244,7 +261,7 @@ get_master_key_info(void)
     TDEMasterKeyInfo *masterKeyInfo = NULL;
     File master_key_file = -1;
     off_t bytes_read = 0;
-    char *info_file_path = get_master_key_info_path();
+    char *info_file_path = get_master_key_info_path(NULL);
 
     /*
      * If file does not exists or does not contain the valid
@@ -314,7 +331,7 @@ GetMasterKey(void)
         return NULL;
     }
 
-    keyInfo = KeyringGetKey(keyring, masterKeyInfo->keyName, false, &keyring_ret);
+    keyInfo = KeyringGetKey(keyring, masterKeyInfo->keyId.name, false, &keyring_ret);
     if (keyInfo == NULL)
     {
         ereport(ERROR,
@@ -324,9 +341,8 @@ GetMasterKey(void)
 
     masterKey = palloc(sizeof(TDEMasterKey));
     masterKey->databaseId = masterKeyInfo->databaseId;
-    masterKey->keyVersion = masterKeyInfo->keyVersion;
     masterKey->keyringId = masterKeyInfo->keyringId;
-    strncpy(masterKey->keyName, masterKeyInfo->keyName, TDE_KEY_NAME_LEN);
+    memcpy(&masterKey->keyId, &masterKeyInfo->keyId, sizeof(TDEMasterKeyId));
     masterKey->keyLength = keyInfo->data.len;
     memcpy(masterKey->keyData, keyInfo->data.data, keyInfo->data.len);
 
@@ -392,9 +408,9 @@ set_master_key_with_keyring(const char *key_name, GenericKeyring *keyring)
         KeyringReturnCodes keyring_ret;
         masterKey = palloc(sizeof(TDEMasterKey));
         masterKey->databaseId = MyDatabaseId;
-        masterKey->keyVersion = 1;
+        masterKey->keyId.version = 1;
         masterKey->keyringId = keyring->key_id;
-        strncpy(masterKey->keyName, key_name, TDE_KEY_NAME_LEN);
+        strncpy(masterKey->keyId.name, key_name, TDE_KEY_NAME_LEN);
         /* We need to get the key from keyring */
 
         keyInfo = KeyringGetKey(keyring, key_name, false, &keyring_ret);
@@ -409,7 +425,14 @@ set_master_key_with_keyring(const char *key_name, GenericKeyring *keyring)
         }
         masterKey->keyLength = keyInfo->data.len;
         memcpy(masterKey->keyData, keyInfo->data.data, keyInfo->data.len);
-        masterKeyInfo = save_master_key_info(masterKey, keyring);
+        masterKeyInfo = create_master_key_info(masterKey, keyring);
+        save_master_key_info(masterKeyInfo);
+
+        /* XLog the new key*/
+        XLogBeginInsert();
+	    XLogRegisterData((char *) masterKeyInfo, sizeof(TDEMasterKeyInfo));
+	    XLogInsert(RM_TDERMGR_ID, XLOG_TDE_ADD_MASTER_KEY);
+        
         push_master_key_to_cache(masterKey);
     }
     else
@@ -537,7 +560,6 @@ push_master_key_to_cache(TDEMasterKey *masterKey)
  * Idelly we should have a mechanism to remove these when the extension
  * but unfortunately we do not have any such mechanism in PG.
 */
-
 static void
 master_key_startup_cleanup(int tde_tbl_count, void* arg)
 {
@@ -553,7 +575,7 @@ master_key_startup_cleanup(int tde_tbl_count, void* arg)
         return;
     }
 
-    info_file_path = get_master_key_info_path();
+    info_file_path = get_master_key_info_path(NULL);
 
     /* Start with deleting the cache entry for the database */
     cache_entry = (TDEMasterKey *)dshash_find(get_master_key_Hash(),

--- a/src/catalog/tde_master_key.c
+++ b/src/catalog/tde_master_key.c
@@ -273,11 +273,6 @@ get_master_key_info(void)
 
     masterKeyInfo = palloc(sizeof(TDEMasterKeyInfo));
     bytes_read = FileRead(master_key_file, masterKeyInfo, sizeof(TDEMasterKeyInfo), 0, WAIT_EVENT_DATA_FILE_READ);
-    if (bytes_read == 0)
-    {
-        pfree(masterKeyInfo);
-        return NULL;
-    }
     if (bytes_read != sizeof(TDEMasterKeyInfo))
     {
         pfree(masterKeyInfo);
@@ -597,12 +592,8 @@ master_key_startup_cleanup(int tde_tbl_count, void* arg)
     }
     else
     {
-        if (FileTruncate(master_key_file, 0, WAIT_EVENT_DATA_FILE_TRUNCATE) < 0)
-            ereport(WARNING,
-                    (errcode_for_file_access(),
-                     errmsg("could not truncate file \"%s\": %m",
-                            info_file_path)));
         FileClose(master_key_file);
+        durable_unlink(info_file_path, WARNING);
     }
 }
 

--- a/src/include/access/pg_tde_tdemap.h
+++ b/src/include/access/pg_tde_tdemap.h
@@ -21,8 +21,8 @@ typedef struct InternalKey
 
 typedef struct RelKeyData
 {
-    char        master_key_name[MASTER_KEY_NAME_LEN];
-    InternalKey internal_key;
+    TDEMasterKeyId  master_key_id;
+    InternalKey     internal_key;
 } RelKeyData;
 
 /* Relation key cache.
@@ -39,6 +39,13 @@ typedef struct RelKey
     struct RelKey *next;
 } RelKey;
 
+typedef struct XLogRelKey
+{
+	RelFileLocator  rlocator;
+	RelKeyData      relKey;
+} XLogRelKey;
+
+extern void pg_tde_write_key_map_entry(const RelFileLocator *rlocator, RelKeyData *enc_rel_key_data, bool fail_on_check);
 extern void pg_tde_delete_key_map_entry(const RelFileLocator *rlocator);
 extern void pg_tde_free_key_map_entry(const RelFileLocator *rlocator, off_t offset);
 extern void pg_tde_create_key_map_entry(const RelFileLocator *newrlocator, Relation rel);
@@ -48,23 +55,4 @@ extern void pg_tde_cleanup_path_vars(void);
 
 const char * tde_sprint_key(InternalKey *k);
 
-/* TDE XLOG resource manager */
-#define XLOG_TDE_RELATION_KEY   0x00
-/* TODO: ID has to be registedred and changed: https://wiki.postgresql.org/wiki/CustomWALResourceManagers */
-#define RM_TDERMGR_ID          RM_EXPERIMENTAL_ID
-#define RM_TDERMGR_NAME        "test_pg_tde_custom_rmgr"
-
-extern void            pg_tde_rmgr_redo(XLogReaderState *record);
-extern void            pg_tde_rmgr_desc(StringInfo buf, XLogReaderState *record);
-extern const char *    pg_tde_rmgr_identify(uint8 info);
-
-
-/* Move this to pg_tde.c file */
-static const RmgrData pg_tde_rmgr = {
-	.rm_name = RM_TDERMGR_NAME,
-	.rm_redo = pg_tde_rmgr_redo,
-	.rm_desc = pg_tde_rmgr_desc,
-	.rm_identify = pg_tde_rmgr_identify
-};
-
-#endif                            /* PG_TDE_MAP_H */
+#endif /*PG_TDE_MAP_H*/

--- a/src/include/access/pg_tde_xlog.h
+++ b/src/include/access/pg_tde_xlog.h
@@ -1,7 +1,7 @@
 /*-------------------------------------------------------------------------
  *
  * pg_tde_xlog.h
- *	  TDE XLog resource namager
+ *	  TDE XLog resource manager
  *
  *-------------------------------------------------------------------------
  */
@@ -12,17 +12,17 @@
 #include "access/xlog_internal.h"
 
 /* TDE XLOG resource manager */
-#define XLOG_TDE_ADD_RELATION_KEY   0x00
-#define XLOG_TDE_ADD_MASTER_KEY     0x10
+#define XLOG_TDE_ADD_RELATION_KEY	0x00
+#define XLOG_TDE_ADD_MASTER_KEY		0x10
+#define XLOG_TDE_CLEAN_MASTER_KEY	0x20
 /* TODO: ID has to be registedred and changed: https://wiki.postgresql.org/wiki/CustomWALResourceManagers */
-#define RM_TDERMGR_ID          RM_EXPERIMENTAL_ID
-#define RM_TDERMGR_NAME        "test_pg_tde_custom_rmgr"
+#define RM_TDERMGR_ID	RM_EXPERIMENTAL_ID
+#define RM_TDERMGR_NAME	"test_pg_tde_custom_rmgr"
 
 extern void pg_tde_rmgr_redo(XLogReaderState *record);
 extern void pg_tde_rmgr_desc(StringInfo buf, XLogReaderState *record);
 extern const char *pg_tde_rmgr_identify(uint8 info);
 
-/* Move this to pg_tde.c file */
 static const RmgrData pg_tde_rmgr = {
 	.rm_name = RM_TDERMGR_NAME,
 	.rm_redo = pg_tde_rmgr_redo,

--- a/src/include/access/pg_tde_xlog.h
+++ b/src/include/access/pg_tde_xlog.h
@@ -1,0 +1,33 @@
+/*-------------------------------------------------------------------------
+ *
+ * pg_tde_xlog.h
+ *	  TDE XLog resource namager
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef PG_TDE_XLOG_H
+#define PG_TDE_XLOG_H
+
+#include "access/xlog_internal.h"
+
+/* TDE XLOG resource manager */
+#define XLOG_TDE_ADD_RELATION_KEY   0x00
+#define XLOG_TDE_ADD_MASTER_KEY     0x10
+/* TODO: ID has to be registedred and changed: https://wiki.postgresql.org/wiki/CustomWALResourceManagers */
+#define RM_TDERMGR_ID          RM_EXPERIMENTAL_ID
+#define RM_TDERMGR_NAME        "test_pg_tde_custom_rmgr"
+
+extern void pg_tde_rmgr_redo(XLogReaderState *record);
+extern void pg_tde_rmgr_desc(StringInfo buf, XLogReaderState *record);
+extern const char *pg_tde_rmgr_identify(uint8 info);
+
+/* Move this to pg_tde.c file */
+static const RmgrData pg_tde_rmgr = {
+	.rm_name = RM_TDERMGR_NAME,
+	.rm_redo = pg_tde_rmgr_redo,
+	.rm_desc = pg_tde_rmgr_desc,
+	.rm_identify = pg_tde_rmgr_identify
+};
+
+#endif							/* PG_TDE_XLOG_H */

--- a/src/include/catalog/tde_master_key.h
+++ b/src/include/catalog/tde_master_key.h
@@ -7,8 +7,8 @@
  *
  *-------------------------------------------------------------------------
  */
-#ifndef TDE_MASTER_KEY_H
-#define TDE_MASTER_KEY_H
+#ifndef PG_TDE_MASTER_KEY_H
+#define PG_TDE_MASTER_KEY_H
 
 
 #include "postgres.h"
@@ -18,31 +18,35 @@
 
 #define MASTER_KEY_NAME_LEN TDE_KEY_NAME_LEN
 
+typedef struct TDEMasterKeyId
+{
+	uint32	version;
+	char	name[MASTER_KEY_NAME_LEN];
+} TDEMasterKeyId;
+
 typedef struct TDEMasterKey
 {
+	TDEMasterKeyId keyId;
 	Oid databaseId;
-	uint32 keyVersion;
 	Oid keyringId;
-	char keyName[MASTER_KEY_NAME_LEN];
 	unsigned char keyData[MAX_KEY_DATA_SIZE];
 	uint32 keyLength;
 } TDEMasterKey;
 
-
 typedef struct TDEMasterKeyInfo
 {
-	Oid keyId;
 	Oid keyringId;
 	Oid databaseId;
+	Oid tablespaceId;
 	Oid userId;
 	struct timeval creationTime;
-	int keyVersion;
-	char keyName[MASTER_KEY_NAME_LEN];
+	TDEMasterKeyId keyId;
 } TDEMasterKeyInfo;
 
 extern void InitializeMasterKeyInfo(void);
 extern TDEMasterKey* GetMasterKey(void);
 extern TDEMasterKey* SetMasterKey(const char* key_name, const char* provider_name);
 extern Oid GetMasterKeyProviderId(void);
+extern void save_master_key_info(TDEMasterKeyInfo *masterKeyInfo);
 
-#endif /*TDE_MASTER_KEY_H*/
+#endif /*PG_TDE_MASTER_KEY_H*/

--- a/src/include/catalog/tde_master_key.h
+++ b/src/include/catalog/tde_master_key.h
@@ -43,10 +43,17 @@ typedef struct TDEMasterKeyInfo
 	TDEMasterKeyId keyId;
 } TDEMasterKeyInfo;
 
+typedef struct XLogMasterKeyCleanup
+{
+	Oid databaseId;
+	Oid tablespaceId;
+} XLogMasterKeyCleanup;
+
 extern void InitializeMasterKeyInfo(void);
 extern TDEMasterKey* GetMasterKey(void);
 extern TDEMasterKey* SetMasterKey(const char* key_name, const char* provider_name);
 extern Oid GetMasterKeyProviderId(void);
 extern void save_master_key_info(TDEMasterKeyInfo *masterKeyInfo);
+extern void cleanup_master_key_info(Oid databaseId, Oid tablespaceId);
 
 #endif /*PG_TDE_MASTER_KEY_H*/

--- a/src/pg_tde.c
+++ b/src/pg_tde.c
@@ -19,6 +19,7 @@
 #include "storage/lwlock.h"
 #include "storage/shmem.h"
 #include "access/pg_tde_ddl.h"
+#include "access/pg_tde_xlog.h"
 #include "encryption/enc_aes.h"
 #include "access/pg_tde_tdemap.h"
 #include "keyring/keyring_config.h"


### PR DESCRIPTION
Fix internal key XLogging for keyring changes 

1. There is no functional relation cache during XLog replay therefore
`GetMasterKey()` would fail looking for the keyring namespace. Actually,
it would fail earlier on `get_master_key_info_path()`  as XLog replay
has its own `MyDatabaseId` and `MyDatabaseTableSpace`. The latter could
be fixed by providing `RelFileLocator` to `GetMasterKey()`  but the former
can't be fixed easily (if it could be fixed at all) as XLog replay deals
with the `Buffer` and shouldn't have access to the relations. To solve this,
we should pass the master key name in the XLog so there is no need to call
`GetMasterKey()` during XLog redo.

It also doesn't make sense to add an internal key to the cache during XLog
replay as this cache is per-process and it won't be available to any user
connections.

2. Replicate the Master Key Info file on `pg_tde_set_master_key()`.

3. Use Master Key Version along with the Master Key Name in `pg_tde.*` headers.