### PR TITLE
Keyrotation and key name versioning implementation

### DIFF
--- a/expected/insert_update_delete.out
+++ b/expected/insert_update_delete.out
@@ -8,7 +8,7 @@ SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per')
 SELECT pg_tde_set_master_key('test-db-master-key','file-vault');
  pg_tde_set_master_key 
 -----------------------
- 
+ t
 (1 row)
 
 CREATE TABLE albums (

--- a/expected/keyprovider_dependency.out
+++ b/expected/keyprovider_dependency.out
@@ -20,7 +20,7 @@ SELECT pg_tde_add_key_provider_vault_v2('V2-vault','vault-token','percona.com/va
 SELECT pg_tde_set_master_key('test-db-master-key','mk-file');
  pg_tde_set_master_key 
 -----------------------
- 
+ t
 (1 row)
 
 -- Try dropping the in-use key provider

--- a/expected/move_large_tuples.out
+++ b/expected/move_large_tuples.out
@@ -9,7 +9,7 @@ SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per')
 SELECT pg_tde_set_master_key('test-db-master-key','file-vault');
  pg_tde_set_master_key 
 -----------------------
- 
+ t
 (1 row)
 
 CREATE TABLE sbtest2(

--- a/expected/multi_insert.out
+++ b/expected/multi_insert.out
@@ -10,7 +10,7 @@ SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per')
 SELECT pg_tde_set_master_key('test-db-master-key','file-vault');
  pg_tde_set_master_key 
 -----------------------
- 
+ t
 (1 row)
 
 CREATE TABLE albums (

--- a/expected/non_sorted_off_compact.out
+++ b/expected/non_sorted_off_compact.out
@@ -10,7 +10,7 @@ SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per')
 SELECT pg_tde_set_master_key('test-db-master-key','file-vault');
  pg_tde_set_master_key 
 -----------------------
- 
+ t
 (1 row)
 
 DROP TABLE IF EXISTS sbtest1;

--- a/expected/pgtde_is_encrypted.out
+++ b/expected/pgtde_is_encrypted.out
@@ -8,7 +8,7 @@ SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per')
 SELECT pg_tde_set_master_key('test-db-master-key','file-vault');
  pg_tde_set_master_key 
 -----------------------
- 
+ t
 (1 row)
 
 CREATE TABLE test_enc(

--- a/expected/toast_decrypt.out
+++ b/expected/toast_decrypt.out
@@ -8,7 +8,7 @@ SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per')
 SELECT pg_tde_set_master_key('test-db-master-key','file-vault');
  pg_tde_set_master_key 
 -----------------------
- 
+ t
 (1 row)
 
 CREATE TABLE src (f1 TEXT STORAGE EXTERNAL) USING pg_tde;

--- a/expected/toast_extended_storage.out
+++ b/expected/toast_extended_storage.out
@@ -9,7 +9,7 @@ SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per')
 SELECT pg_tde_set_master_key('test-db-master-key','file-vault');
  pg_tde_set_master_key 
 -----------------------
- 
+ t
 (1 row)
 
 CREATE TEMP TABLE src (f1 text) USING pg_tde;

--- a/expected/trigger_on_view.out
+++ b/expected/trigger_on_view.out
@@ -8,7 +8,7 @@ SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per')
 SELECT pg_tde_set_master_key('test-db-master-key','file-vault');
  pg_tde_set_master_key 
 -----------------------
- 
+ t
 (1 row)
 
 --

--- a/expected/update_compare_indexes.out
+++ b/expected/update_compare_indexes.out
@@ -8,7 +8,7 @@ SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per')
 SELECT pg_tde_set_master_key('test-db-master-key','file-vault');
  pg_tde_set_master_key 
 -----------------------
- 
+ t
 (1 row)
 
 DROP TABLE IF EXISTS pvactst;

--- a/expected/vault_v2_test.out
+++ b/expected/vault_v2_test.out
@@ -9,7 +9,7 @@ SELECT pg_tde_add_key_provider_vault_v2('vault-v2',:'root_token','http://127.0.0
 SELECT pg_tde_set_master_key('vault-v2-master-key','vault-v2');
  pg_tde_set_master_key 
 -----------------------
- 
+ t
 (1 row)
 
 CREATE TABLE test_enc(

--- a/meson.build
+++ b/meson.build
@@ -84,6 +84,7 @@ tests += {
   'tap': {
     'tests': [
       't/001_basic.pl',
+      't/002_rotate_key.pl',
     ],
   },
 }

--- a/pg_tde--1.0.sql
+++ b/pg_tde--1.0.sql
@@ -81,12 +81,12 @@ RETURNS boolean
 AS $$ SELECT amname = 'pg_tde' FROM pg_class INNER JOIN pg_am ON pg_am.oid = pg_class.relam WHERE relname = table_name $$
 LANGUAGE SQL;
 
-CREATE FUNCTION pg_tde_rotate_key(new_master_key_name VARCHAR(255), new_provider_name VARCHAR(255))
+CREATE FUNCTION pg_tde_rotate_key(new_master_key_name VARCHAR(255) DEFAULT NULL, new_provider_name VARCHAR(255) DEFAULT NULL, ensure_new_key BOOLEAN DEFAULT TRUE)
 RETURNS boolean
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
-CREATE FUNCTION pg_tde_set_master_key(master_key_name VARCHAR(255), provider_name VARCHAR(255))
+CREATE FUNCTION pg_tde_set_master_key(master_key_name VARCHAR(255), provider_name VARCHAR(255), ensure_new_key BOOLEAN DEFAULT FALSE)
 RETURNS boolean
 AS 'MODULE_PATHNAME'
 LANGUAGE C;

--- a/pg_tde--1.0.sql
+++ b/pg_tde--1.0.sql
@@ -81,13 +81,13 @@ RETURNS boolean
 AS $$ SELECT amname = 'pg_tde' FROM pg_class INNER JOIN pg_am ON pg_am.oid = pg_class.relam WHERE relname = table_name $$
 LANGUAGE SQL;
 
-CREATE FUNCTION pg_tde_rotate_key(key_name VARCHAR)
+CREATE FUNCTION pg_tde_rotate_key(new_master_key_name VARCHAR(255), new_provider_name VARCHAR(255))
 RETURNS boolean
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
 CREATE FUNCTION pg_tde_set_master_key(master_key_name VARCHAR(255), provider_name VARCHAR(255))
-RETURNS VOID
+RETURNS boolean
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 

--- a/src/access/pg_tde_tdemap.c
+++ b/src/access/pg_tde_tdemap.c
@@ -979,12 +979,12 @@ void
 finalize_key_rotation(char *m_path_old, char *k_path_old, char *m_path_new, char *k_path_new)
 {
 	/* Remove old files */
-	durable_unlink(m_path_old, LOG);
-	durable_unlink(k_path_old, LOG);
+	durable_unlink(m_path_old, ERROR);
+	durable_unlink(k_path_old, ERROR);
 
 	/* Rename the new files to required filenames */
-	durable_rename(m_path_new, m_path_old, LOG);
-	durable_rename(k_path_new, k_path_old, LOG);
+	durable_rename(m_path_new, m_path_old, ERROR);
+	durable_rename(k_path_new, k_path_old, ERROR);
 }
 
 /*

--- a/src/access/pg_tde_xlog.c
+++ b/src/access/pg_tde_xlog.c
@@ -46,6 +46,12 @@ pg_tde_rmgr_redo(XLogReaderState *record)
 
 		cleanup_master_key_info(xlrec->databaseId, xlrec->tablespaceId);
 	}
+	else if (info == XLOG_TDE_ROTATE_KEY)
+	{
+		XLogMasterKeyRotate *xlrec = (XLogMasterKeyRotate *) XLogRecGetData(record);
+
+		xl_tde_perform_rotate_key(xlrec);
+	}
 	else
 	{
 		elog(PANIC, "pg_tde_redo: unknown op code %u", info);
@@ -74,6 +80,12 @@ pg_tde_rmgr_desc(StringInfo buf, XLogReaderState *record)
 		XLogMasterKeyCleanup *xlrec = (XLogMasterKeyCleanup *) XLogRecGetData(record);
 
 		appendStringInfo(buf, "cleanup tde master key info for db %u/%u", xlrec->databaseId, xlrec->tablespaceId);
+	}
+	if (info == XLOG_TDE_ROTATE_KEY)
+	{
+		XLogMasterKeyRotate *xlrec = (XLogMasterKeyRotate *) XLogRecGetData(record);
+
+		appendStringInfo(buf, "rotate master key for %u", xlrec->databaseId);
 	}
 }
 

--- a/src/catalog/tde_keyring.c
+++ b/src/catalog/tde_keyring.c
@@ -164,6 +164,13 @@ GetKeyProviderByName(const char *provider_name)
 	heap_endscan(scan);
 	relation_close(kp_table_relation, AccessShareLock);
 
+    if (keyring == NULL)
+    {
+        ereport(ERROR,
+                (errmsg("Key provider \"%s\" does not exists", provider_name),
+                 errhint("Use create_key_provider interface to create the key provider")));
+    }
+
 	return keyring;
 }
 

--- a/src/catalog/tde_master_key.c
+++ b/src/catalog/tde_master_key.c
@@ -432,7 +432,7 @@ RotateMasterKey(const char *new_key_name, const char *new_provider_name)
         if (new_master_key.keyInfo.keyId.version > MAX_MASTER_KEY_VERSION_NUM)
         {
             ereport(ERROR,
-                    (errmsg("Failed to generate new key name")));
+                    (errmsg("failed to retrieve master key")));
             break;
         }
     }
@@ -443,7 +443,7 @@ RotateMasterKey(const char *new_key_name, const char *new_provider_name)
     if (keyInfo == NULL)
     {
         ereport(ERROR,
-                (errmsg("failed to retrieve master key")));
+                (errmsg("Failed to generate new key name")));
     }
 
     new_master_key.keyLength = keyInfo->data.len;

--- a/src/catalog/tde_master_key.c
+++ b/src/catalog/tde_master_key.c
@@ -435,7 +435,8 @@ load_latest_versioned_key_name(TDEMasterKeyInfo *mastere_key_info, GenericKeyrin
     while (true)
     {
         keyInfo = KeyringGetKey(keyring, mastere_key_info->keyId.versioned_name, false, &kr_ret);
-        if (kr_ret != KEYRING_CODE_SUCCESS)
+        /* vault-v2 returns 404 (KEYRING_CODE_RESOURCE_NOT_AVAILABLE) when key is not found */
+        if (kr_ret != KEYRING_CODE_SUCCESS && kr_ret != KEYRING_CODE_RESOURCE_NOT_AVAILABLE)
         {
             ereport(ERROR,
                 (errmsg("failed to retrieve master key from keyring provider :\"%s\"", keyring->provider_name),

--- a/src/catalog/tde_master_key.c
+++ b/src/catalog/tde_master_key.c
@@ -412,6 +412,20 @@ RotateMasterKey(const char *new_key_name, const char *new_provider_name, bool en
 }
 
 /*
+ * Rotate keys on a standby.
+ */
+bool
+xl_tde_perform_rotate_key(XLogMasterKeyRotate *xlrec)
+{
+    bool ret;
+
+    ret = pg_tde_write_map_keydata_files(xlrec->map_size, xlrec->buff, xlrec->keydata_size, &xlrec->buff[xlrec->map_size]);
+    clear_master_key_cache(MyDatabaseId, MyDatabaseTableSpace);
+
+	return ret;
+}
+
+/*
 * Load the latest versioned key name for the master key
 * If ensure_new_key is true, then we will keep on incrementing the version number
 * till we get a key name that is not present in the keyring

--- a/src/catalog/tde_master_key.c
+++ b/src/catalog/tde_master_key.c
@@ -233,7 +233,7 @@ GetMasterKey(void)
     if (keyInfo == NULL)
     {
         ereport(ERROR,
-                (errmsg("failed to retrieve master key from keyring %s", masterKeyInfo->keyId.versioned_name)));
+                (errmsg("failed to retrieve master key \"%s\" from keyring.", masterKeyInfo->keyId.versioned_name)));
         return NULL;
     }
 

--- a/src/include/access/pg_tde_tdemap.h
+++ b/src/include/access/pg_tde_tdemap.h
@@ -46,16 +46,20 @@ typedef struct XLogRelKey
 	RelKeyData      relKey;
 } XLogRelKey;
 
+extern void pg_tde_create_key_map_entry(const RelFileLocator *newrlocator, Relation rel);
 extern void pg_tde_write_key_map_entry(const RelFileLocator *rlocator, RelKeyData *enc_rel_key_data, TDEMasterKeyInfo *master_key_info);
 extern void pg_tde_delete_key_map_entry(const RelFileLocator *rlocator);
 extern void pg_tde_free_key_map_entry(const RelFileLocator *rlocator, off_t offset);
-extern void pg_tde_create_key_map_entry(const RelFileLocator *newrlocator, Relation rel);
+
 extern RelKeyData *pg_tde_get_key_from_fork(const RelFileLocator *rlocator);
 extern RelKeyData *GetRelationKey(RelFileLocator rel);
+
 extern void pg_tde_cleanup_path_vars(void);
 extern void pg_tde_delete_tde_files(Oid dbOid);
-extern bool pg_tde_save_master_key(TDEMasterKeyInfo *master_key_info);
+
 extern TDEMasterKeyInfo *pg_tde_get_master_key(Oid dbOid);
+extern bool pg_tde_save_master_key(TDEMasterKeyInfo *master_key_info);
+extern bool pg_tde_perform_rotate_key(TDEMasterKey *master_key, TDEMasterKey *new_master_key);
 
 const char * tde_sprint_key(InternalKey *k);
 

--- a/src/include/access/pg_tde_tdemap.h
+++ b/src/include/access/pg_tde_tdemap.h
@@ -60,6 +60,7 @@ extern void pg_tde_delete_tde_files(Oid dbOid);
 extern TDEMasterKeyInfo *pg_tde_get_master_key(Oid dbOid);
 extern bool pg_tde_save_master_key(TDEMasterKeyInfo *master_key_info);
 extern bool pg_tde_perform_rotate_key(TDEMasterKey *master_key, TDEMasterKey *new_master_key);
+extern bool xl_tde_perform_rotate_key(XLogMasterKeyRotate *xlrec);
 
 const char * tde_sprint_key(InternalKey *k);
 

--- a/src/include/access/pg_tde_tdemap.h
+++ b/src/include/access/pg_tde_tdemap.h
@@ -60,7 +60,7 @@ extern void pg_tde_delete_tde_files(Oid dbOid);
 extern TDEMasterKeyInfo *pg_tde_get_master_key(Oid dbOid);
 extern bool pg_tde_save_master_key(TDEMasterKeyInfo *master_key_info);
 extern bool pg_tde_perform_rotate_key(TDEMasterKey *master_key, TDEMasterKey *new_master_key);
-extern bool xl_tde_perform_rotate_key(XLogMasterKeyRotate *xlrec);
+extern bool pg_tde_write_map_keydata_files(off_t map_size, char *m_file_data, off_t keydata_size, char *k_file_data);
 
 const char * tde_sprint_key(InternalKey *k);
 

--- a/src/include/access/pg_tde_xlog.h
+++ b/src/include/access/pg_tde_xlog.h
@@ -15,6 +15,8 @@
 #define XLOG_TDE_ADD_RELATION_KEY	0x00
 #define XLOG_TDE_ADD_MASTER_KEY		0x10
 #define XLOG_TDE_CLEAN_MASTER_KEY	0x20
+#define XLOG_TDE_ROTATE_KEY			0x30
+
 /* TODO: ID has to be registedred and changed: https://wiki.postgresql.org/wiki/CustomWALResourceManagers */
 #define RM_TDERMGR_ID	RM_EXPERIMENTAL_ID
 #define RM_TDERMGR_NAME	"test_pg_tde_custom_rmgr"

--- a/src/include/catalog/tde_master_key.h
+++ b/src/include/catalog/tde_master_key.h
@@ -18,7 +18,6 @@
 
 #define MASTER_KEY_NAME_LEN TDE_KEY_NAME_LEN
 #define MAX_MASTER_KEY_VERSION_NUM 1000
-#define DEFAULUT_MASTER_KEY_VERSION 1
 
 typedef struct TDEMasterKeyId
 {
@@ -43,6 +42,16 @@ typedef struct TDEMasterKey
 	unsigned char keyData[MAX_KEY_DATA_SIZE];
 	uint32 keyLength;
 } TDEMasterKey;
+
+typedef struct XLogMasterKeyRotate
+{
+	Oid databaseId;
+	off_t map_size;
+	off_t keydata_size;
+	char  buff[FLEXIBLE_ARRAY_MEMBER];
+} XLogMasterKeyRotate;
+
+#define SizeoOfXLogMasterKeyRotate	offsetof(XLogMasterKeyRotate, buff)
 
 typedef struct XLogMasterKeyCleanup
 {

--- a/src/include/catalog/tde_master_key.h
+++ b/src/include/catalog/tde_master_key.h
@@ -17,11 +17,14 @@
 #include "nodes/pg_list.h"
 
 #define MASTER_KEY_NAME_LEN TDE_KEY_NAME_LEN
+#define MAX_MASTER_KEY_VERSION_NUM 1000
+#define DEFAULUT_MASTER_KEY_VERSION 1
 
 typedef struct TDEMasterKeyId
 {
 	uint32	version;
 	char	name[MASTER_KEY_NAME_LEN];
+	char	versioned_name[MASTER_KEY_NAME_LEN + 4];
 } TDEMasterKeyId;
 
 typedef struct TDEMasterKeyInfo

--- a/src/include/catalog/tde_master_key.h
+++ b/src/include/catalog/tde_master_key.h
@@ -68,5 +68,6 @@ extern Oid GetMasterKeyProviderId(void);
 extern TDEMasterKey* GetMasterKey(void);
 extern bool SetMasterKey(const char *key_name, const char *provider_name, bool ensure_new_key);
 extern bool RotateMasterKey(const char *new_key_name, const char *new_provider_name, bool ensure_new_key);
+extern bool xl_tde_perform_rotate_key(XLogMasterKeyRotate *xlrec);
 
 #endif /*PG_TDE_MASTER_KEY_H*/

--- a/src/include/catalog/tde_master_key.h
+++ b/src/include/catalog/tde_master_key.h
@@ -48,10 +48,13 @@ typedef struct XLogMasterKeyCleanup
 } XLogMasterKeyCleanup;
 
 extern void InitializeMasterKeyInfo(void);
-extern TDEMasterKey* GetMasterKey(Oid dbOid);
-extern TDEMasterKey* SetMasterKey(const char* key_name, const char* provider_name);
-extern Oid GetMasterKeyProviderId(void);
-extern bool save_master_key_info(TDEMasterKeyInfo *masterKeyInfo);
 extern void cleanup_master_key_info(Oid databaseId, Oid tablespaceId);
+
+extern bool save_master_key_info(TDEMasterKeyInfo *masterKeyInfo);
+
+extern Oid GetMasterKeyProviderId(void);
+extern TDEMasterKey* GetMasterKey(void);
+extern bool SetMasterKey(const char *key_name, const char *provider_name);
+extern bool RotateMasterKey(const char *new_key_name, const char *new_provider_name);
 
 #endif /*PG_TDE_MASTER_KEY_H*/

--- a/src/include/catalog/tde_master_key.h
+++ b/src/include/catalog/tde_master_key.h
@@ -17,7 +17,7 @@
 #include "nodes/pg_list.h"
 
 #define MASTER_KEY_NAME_LEN TDE_KEY_NAME_LEN
-#define MAX_MASTER_KEY_VERSION_NUM 1000
+#define MAX_MASTER_KEY_VERSION_NUM 100000
 
 typedef struct TDEMasterKeyId
 {
@@ -66,7 +66,7 @@ extern bool save_master_key_info(TDEMasterKeyInfo *masterKeyInfo);
 
 extern Oid GetMasterKeyProviderId(void);
 extern TDEMasterKey* GetMasterKey(void);
-extern bool SetMasterKey(const char *key_name, const char *provider_name);
-extern bool RotateMasterKey(const char *new_key_name, const char *new_provider_name);
+extern bool SetMasterKey(const char *key_name, const char *provider_name, bool ensure_new_key);
+extern bool RotateMasterKey(const char *new_key_name, const char *new_provider_name, bool ensure_new_key);
 
 #endif /*PG_TDE_MASTER_KEY_H*/

--- a/src/keyring/keyring_file.c
+++ b/src/keyring/keyring_file.c
@@ -45,14 +45,11 @@ get_key_by_name(GenericKeyring* keyring, const char* key_name, bool throw_error,
 	off_t bytes_read = 0;
 	off_t curr_pos = 0;
 
-	file = PathNameOpenFile(file_keyring->file_name, O_CREAT | O_RDWR | PG_BINARY);
+	*return_code = KEYRING_CODE_SUCCESS;
+
+	file = PathNameOpenFile(file_keyring->file_name, PG_BINARY);
 	if (file < 0)
-	{
-		*return_code = KEYRING_CODE_RESOURCE_NOT_ACCESSABLE;
-			ereport(throw_error ? ERROR : NOTICE,
-					(errmsg("Failed to open keyring file :%s %m", file_keyring->file_name)));
 		return NULL;
-	}
 
 	key = palloc(sizeof(keyInfo));
 	while(true)
@@ -62,19 +59,24 @@ get_key_by_name(GenericKeyring* keyring, const char* key_name, bool throw_error,
 
 		if (bytes_read == 0 )
 		{
+			/*
+			 * Empty keyring file is considered as a valid keyring file that has no keys
+			 */
+			FileClose(file);
 			pfree(key);
-			*return_code = KEYRING_CODE_RESOURCE_NOT_AVAILABLE;
 			return NULL;
 		}
 		if (bytes_read != sizeof(keyInfo))
 		{
+			FileClose(file);
 			pfree(key);
 			/* Corrupt file */
 			*return_code = KEYRING_CODE_DATA_CORRUPTED;
 			ereport(throw_error?ERROR:WARNING,
 				(errcode_for_file_access(),
 					errmsg("keyring file \"%s\" is corrupted: %m",
-						file_keyring->file_name)));
+						file_keyring->file_name),
+						errdetail("invalid key size %d expected %d", bytes_read, sizeof(keyInfo))));
 			return NULL;
 		}
 		if (strncasecmp(key->name.name, key_name, sizeof(key->name.name)) == 0)
@@ -83,7 +85,6 @@ get_key_by_name(GenericKeyring* keyring, const char* key_name, bool throw_error,
 			return key;
 		}
 	}
-	*return_code = KEYRING_CODE_SUCCESS;
 	FileClose(file);
 	pfree(key);
     return NULL;
@@ -93,7 +94,8 @@ static KeyringReturnCodes
 set_key_by_name(GenericKeyring* keyring, keyInfo *key, bool throw_error)
 {
     off_t bytes_written = 0;
-	File file;
+	off_t curr_pos = 0;
+		File file;
 	FileKeyring* file_keyring = (FileKeyring*)keyring;
 	keyInfo *existing_key;
 	KeyringReturnCodes return_code = KEYRING_CODE_SUCCESS;
@@ -118,9 +120,11 @@ set_key_by_name(GenericKeyring* keyring, keyInfo *key, bool throw_error)
         return KEYRING_CODE_RESOURCE_NOT_ACCESSABLE;
     }
 	/* Write key to the end of file */
-	lseek(file, 0, SEEK_END);
-	bytes_written = FileWrite(file, key, sizeof(keyInfo), 0, WAIT_EVENT_DATA_FILE_WRITE);
-    if (bytes_written != sizeof(keyInfo))
+	curr_pos = FileSize(file);
+	ereport(NOTICE,
+			(errmsg("Writing key to file %s at offset %ld", file_keyring->file_name, curr_pos)));
+	bytes_written = FileWrite(file, key, sizeof(keyInfo), curr_pos, WAIT_EVENT_DATA_FILE_WRITE);
+	if (bytes_written != sizeof(keyInfo))
     {
         FileClose(file);
         ereport(throw_error?ERROR:WARNING,

--- a/src/keyring/keyring_file.c
+++ b/src/keyring/keyring_file.c
@@ -42,6 +42,8 @@ get_key_by_name(GenericKeyring* keyring, const char* key_name, bool throw_error,
 	keyInfo* key = NULL;
 	File file = -1;
 	FileKeyring* file_keyring = (FileKeyring*)keyring;
+	off_t bytes_read = 0;
+	off_t curr_pos = 0;
 
 	file = PathNameOpenFile(file_keyring->file_name, O_CREAT | O_RDWR | PG_BINARY);
 	if (file < 0)
@@ -55,8 +57,9 @@ get_key_by_name(GenericKeyring* keyring, const char* key_name, bool throw_error,
 	key = palloc(sizeof(keyInfo));
 	while(true)
 	{
-		off_t bytes_read = 0;
-		bytes_read = FileRead(file, key, sizeof(keyInfo), 0, WAIT_EVENT_DATA_FILE_READ);
+		bytes_read = FileRead(file, key, sizeof(keyInfo), curr_pos, WAIT_EVENT_DATA_FILE_READ);
+		curr_pos += bytes_read;
+
 		if (bytes_read == 0 )
 		{
 			pfree(key);

--- a/src/keyring/keyring_file.c
+++ b/src/keyring/keyring_file.c
@@ -76,7 +76,7 @@ get_key_by_name(GenericKeyring* keyring, const char* key_name, bool throw_error,
 				(errcode_for_file_access(),
 					errmsg("keyring file \"%s\" is corrupted: %m",
 						file_keyring->file_name),
-						errdetail("invalid key size %d expected %d", bytes_read, sizeof(keyInfo))));
+						errdetail("invalid key size %lu expected %lu", bytes_read, sizeof(keyInfo))));
 			return NULL;
 		}
 		if (strncasecmp(key->name.name, key_name, sizeof(key->name.name)) == 0)

--- a/src/keyring/keyring_file.c
+++ b/src/keyring/keyring_file.c
@@ -121,8 +121,6 @@ set_key_by_name(GenericKeyring* keyring, keyInfo *key, bool throw_error)
     }
 	/* Write key to the end of file */
 	curr_pos = FileSize(file);
-	ereport(NOTICE,
-			(errmsg("Writing key to file %s at offset %ld", file_keyring->file_name, curr_pos)));
 	bytes_written = FileWrite(file, key, sizeof(keyInfo), curr_pos, WAIT_EVENT_DATA_FILE_WRITE);
 	if (bytes_written != sizeof(keyInfo))
     {

--- a/src/keyring/keyring_vault.c
+++ b/src/keyring/keyring_vault.c
@@ -185,6 +185,8 @@ get_key_by_name(GenericKeyring *keyring, const char *key_name, bool throw_error,
 
 	const char* responseKey;
 
+	*return_code = KEYRING_CODE_SUCCESS;
+
 	get_keyring_vault_url(vault_keyring, key_name, url, sizeof(url));
 
 	if (!curl_perform(vault_keyring, url, &str, &httpCode, NULL))

--- a/t/002_rotate_key.pl
+++ b/t/002_rotate_key.pl
@@ -1,0 +1,103 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use File::Basename;
+use File::Compare;
+use File::Copy;
+use Test::More;
+use lib 't';
+use pgtde;
+
+# Get file name and CREATE out file name and dirs WHERE requried
+PGTDE::setup_files_dir(basename($0));
+
+# CREATE new PostgreSQL node and do initdb
+my $node = PGTDE->pgtde_init_pg();
+my $pgdata = $node->data_dir;
+
+# UPDATE postgresql.conf to include/load pg_tde library
+open my $conf, '>>', "$pgdata/postgresql.conf";
+print $conf "shared_preload_libraries = 'pg_tde'\n";
+close $conf;
+
+# Start server
+my $rt_value = $node->start;
+ok($rt_value == 1, "Start Server");
+
+# CREATE EXTENSION and change out file permissions
+my ($cmdret, $stdout, $stderr) = $node->psql('postgres', 'CREATE EXTENSION pg_tde;', extra_params => ['-a']);
+ok($cmdret == 0, "CREATE PGTDE EXTENSION");
+PGTDE::append_to_file($stdout);
+
+
+$rt_value = $node->psql('postgres', 'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING pg_tde;', extra_params => ['-a']);
+ok($rt_value == 3, "Failing query");
+
+
+# Restart the server
+PGTDE::append_to_file("-- server restart");
+$node->stop();
+
+$rt_value = $node->start();
+ok($rt_value == 1, "Restart Server");
+
+$rt_value = $node->psql('postgres', "SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_add_key_provider_file('file-2','/tmp/pg_tde_test_keyring_2.per');", extra_params => ['-a']);
+$rt_value = $node->psql('postgres', "SELECT pg_tde_set_master_key('test-db-master-key','file-vault');", extra_params => ['-a']);
+
+$stdout = $node->safe_psql('postgres', 'CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING pg_tde;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+$stdout = $node->safe_psql('postgres', 'INSERT INTO test_enc (k) VALUES (5),(6);', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+#rotate key
+PGTDE::append_to_file("-- ROTATE KEY pg_tde_rotate_key('rotated-master-key','file-2');");
+$rt_value = $node->psql('postgres', "SELECT pg_tde_rotate_key('rotated-master-key','file-2');", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+# Restart the server
+PGTDE::append_to_file("-- server restart");
+$rt_value = $node->stop();
+$rt_value = $node->start();
+
+$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+#Again rotate key
+PGTDE::append_to_file("-- ROTATE KEY pg_tde_rotate_key();");
+$rt_value = $node->psql('postgres', "SELECT pg_tde_rotate_key();", extra_params => ['-a']);
+$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+# Restart the server
+PGTDE::append_to_file("-- server restart");
+$rt_value = $node->stop();
+$rt_value = $node->start();
+
+$stdout = $node->safe_psql('postgres', 'SELECT * FROM test_enc ORDER BY id ASC;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+$stdout = $node->safe_psql('postgres', 'DROP TABLE test_enc;', extra_params => ['-a']);
+PGTDE::append_to_file($stdout);
+
+# DROP EXTENSION
+$stdout = $node->safe_psql('postgres', 'DROP EXTENSION pg_tde;', extra_params => ['-a']);
+ok($cmdret == 0, "DROP PGTDE EXTENSION");
+PGTDE::append_to_file($stdout);
+# Stop the server
+$node->stop();
+
+# compare the expected and out file
+my $compare = PGTDE->compare_results();
+
+# Test/check if expected and result/out file match. If Yes, test passes.
+is($compare,0,"Compare Files: $PGTDE::expected_filename_with_path and $PGTDE::out_filename_with_path files.");
+
+# Done testing for this testcase file.
+done_testing();

--- a/t/expected/002_rotate_key.out
+++ b/t/expected/002_rotate_key.out
@@ -1,0 +1,25 @@
+CREATE EXTENSION pg_tde;
+-- server restart
+CREATE TABLE test_enc(id SERIAL,k INTEGER,PRIMARY KEY (id)) USING pg_tde;
+INSERT INTO test_enc (k) VALUES (5),(6);
+SELECT * FROM test_enc ORDER BY id ASC;
+1|5
+2|6
+-- ROTATE KEY pg_tde_rotate_key('rotated-master-key','file-2');
+SELECT * FROM test_enc ORDER BY id ASC;
+1|5
+2|6
+-- server restart
+SELECT * FROM test_enc ORDER BY id ASC;
+1|5
+2|6
+-- ROTATE KEY pg_tde_rotate_key();
+SELECT * FROM test_enc ORDER BY id ASC;
+1|5
+2|6
+-- server restart
+SELECT * FROM test_enc ORDER BY id ASC;
+1|5
+2|6
+DROP TABLE test_enc;
+DROP EXTENSION pg_tde;


### PR DESCRIPTION
The initial version of the key rotation functionality without the xlog functionality.
    
This patch includes some minor refactoring as well as changes to the return type of the set key function, which now returns a boolean.

Master key versioning implemented by Usama. A new field of versioned_name is added.
    
Co-authored-by: Muhammad Usama <m.usama@gmail.com>

