### PR TITLE
Fixing OL8 vault issue

### DIFF
--- a/src/keyring/keyring_curl.c
+++ b/src/keyring/keyring_curl.c
@@ -42,7 +42,6 @@ bool curlSetupSession(const char* url, const char* caFile, CurlString* outStr)
     }
 
 	if(curl_easy_setopt(keyringCurl, CURLOPT_SSL_VERIFYPEER, 1) != CURLE_OK) return 0;
-	if(curl_easy_setopt(keyringCurl, CURLOPT_SSL_VERIFYHOST, 1) != CURLE_OK) return 0;
 	if(curl_easy_setopt(keyringCurl, CURLOPT_USE_SSL, CURLUSESSL_ALL) != CURLE_OK) return 0;
 	if(caFile != NULL && strlen(caFile) != 0)
 	{


### PR DESCRIPTION
Old curl versions report an error when we set SSL VERIFYHOST to 1. As the default value is 2, which is usually better, this commit simply removes it from the code.