### PR TITLE
Fix IPC::Run perl module name in CI

### DIFF
--- a/.github/workflows/postgresql-16-pgdg-package-pgxs.yml
+++ b/.github/workflows/postgresql-16-pgdg-package-pgxs.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt-get install -y libreadline6-dev systemtap-sdt-dev wget \
             zlib1g-dev libssl-dev libpam0g-dev bison flex libipc-run-perl \
             libcurl4-openssl-dev  libhttp-server-simple-perl
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
           wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list

--- a/.github/workflows/postgresql-16-src-make-ssl11.yml
+++ b/.github/workflows/postgresql-16-src-make-ssl11.yml
@@ -27,7 +27,7 @@ jobs:
             libsystemd-dev gettext tcl-dev libperl-dev pkg-config \
             libselinux1-dev python3-dev libhttp-server-simple-perl\
             uuid-dev liblz4-dev libcurl4-openssl-dev
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
           wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list

--- a/.github/workflows/postgresql-16-src-make.yml
+++ b/.github/workflows/postgresql-16-src-make.yml
@@ -27,7 +27,7 @@ jobs:
             libsystemd-dev gettext tcl-dev libperl-dev pkg-config clang-11 \
             llvm-11 llvm-11-dev libselinux1-dev python3-dev \
             uuid-dev liblz4-dev libcurl4-openssl-dev libhttp-server-simple-perl
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
           wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list

--- a/.github/workflows/postgresql-16-src-meson-perf.yml
+++ b/.github/workflows/postgresql-16-src-meson-perf.yml
@@ -31,7 +31,7 @@ jobs:
             llvm-11 llvm-11-dev libselinux1-dev python3-dev \
             uuid-dev liblz4-dev meson ninja-build \
             sysbench libcurl4-openssl-dev libhttp-server-simple-perl
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
           wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list

--- a/.github/workflows/postgresql-16-src-meson.yml
+++ b/.github/workflows/postgresql-16-src-meson.yml
@@ -28,7 +28,7 @@ jobs:
             llvm-11 llvm-11-dev libselinux1-dev python3-dev \
             uuid-dev liblz4-dev meson ninja-build  \
             gpg wget libcurl4-openssl-dev libhttp-server-simple-perl
-          sudo /usr/bin/perl -MCPAN -e 'install IPC::RUN'
+          sudo /usr/bin/perl -MCPAN -e 'install IPC::Run'
           sudo /usr/bin/perl -MCPAN -e 'install Text::Trim'
           wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list


### PR DESCRIPTION
```
Warning: Cannot install IPC::RUN, don't know what it is.
Try the command

    i /IPC::RUN/

to find objects with matching identifiers.
```

https://metacpan.org/pod/IPC::Run


Same for pg_stat_monitor: https://github.com/percona/pg_stat_monitor/pull/438