### PR TITLE
Rename tde_master_key_info to pg_tde_master_key_info

### DIFF
--- a/expected/pgtde_is_encrypted.out
+++ b/expected/pgtde_is_encrypted.out
@@ -1,5 +1,5 @@
 CREATE EXTENSION pg_tde;
-SELECT  * FROM tde_master_key_info();
+SELECT  * FROM pg_tde_master_key_info();
 ERROR:  Master key does not exists for the database
 HINT:  Use set_master_key interface to set the master key
 SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
@@ -49,7 +49,7 @@ SELECT pgtde_is_encrypted('test_norm');
 (1 row)
 
 SELECT  key_provider_id, key_provider_name, master_key_name
-		FROM tde_master_key_info();
+		FROM pg_tde_master_key_info();
  key_provider_id | key_provider_name |  master_key_name   
 -----------------+-------------------+--------------------
                1 | file-vault        | test-db-master-key

--- a/pg_tde--1.0.sql
+++ b/pg_tde--1.0.sql
@@ -113,7 +113,7 @@ RETURNS VOID
 AS 'MODULE_PATHNAME'
 LANGUAGE C;
 
-CREATE FUNCTION tde_master_key_info()
+CREATE FUNCTION pg_tde_master_key_info()
 RETURNS TABLE ( master_key_name text,
                 key_provider_name text,
                 key_provider_id integer,

--- a/sql/pgtde_is_encrypted.sql
+++ b/sql/pgtde_is_encrypted.sql
@@ -1,6 +1,6 @@
 CREATE EXTENSION pg_tde;
 
-SELECT  * FROM tde_master_key_info();
+SELECT  * FROM pg_tde_master_key_info();
 
 SELECT pg_tde_add_key_provider_file('file-vault','/tmp/pg_tde_test_keyring.per');
 SELECT pg_tde_set_master_key('test-db-master-key','file-vault');
@@ -24,7 +24,7 @@ SELECT pgtde_is_encrypted('test_enc');
 SELECT pgtde_is_encrypted('test_norm');
 
 SELECT  key_provider_id, key_provider_name, master_key_name
-		FROM tde_master_key_info();
+		FROM pg_tde_master_key_info();
 
 DROP TABLE test_enc;
 DROP TABLE test_norm;

--- a/src/catalog/tde_master_key.c
+++ b/src/catalog/tde_master_key.c
@@ -676,8 +676,8 @@ pg_tde_rotate_key(PG_FUNCTION_ARGS)
     PG_RETURN_BOOL(ret);
 }
 
-PG_FUNCTION_INFO_V1(tde_master_key_info);
-Datum tde_master_key_info(PG_FUNCTION_ARGS)
+PG_FUNCTION_INFO_V1(pg_tde_master_key_info);
+Datum pg_tde_master_key_info(PG_FUNCTION_ARGS)
 {
     TupleDesc tupdesc;
     Datum values[6];


### PR DESCRIPTION
This makes the function names consistent across the extension.