### PR TITLE
Updated locking to include locks on files. This is critical to prevent

### DIFF
--- a/src/include/catalog/tde_master_key.h
+++ b/src/include/catalog/tde_master_key.h
@@ -15,6 +15,7 @@
 #include "catalog/tde_keyring.h"
 #include "keyring/keyring_api.h"
 #include "nodes/pg_list.h"
+#include "storage/lwlock.h"
 
 #define MASTER_KEY_NAME_LEN TDE_KEY_NAME_LEN
 #define MAX_MASTER_KEY_VERSION_NUM 100000
@@ -61,6 +62,8 @@ typedef struct XLogMasterKeyCleanup
 
 extern void InitializeMasterKeyInfo(void);
 extern void cleanup_master_key_info(Oid databaseId, Oid tablespaceId);
+extern LWLock *tde_lwlock_mk_files(void);
+extern LWLock *tde_lwlock_mk_cache(void);
 
 extern bool save_master_key_info(TDEMasterKeyInfo *masterKeyInfo);
 

--- a/src/include/common/pg_tde_shmem.h
+++ b/src/include/common/pg_tde_shmem.h
@@ -16,6 +16,15 @@
 
 #define TDE_TRANCHE_NAME "pg_tde_tranche"
 
+typedef enum
+{
+    TDE_LWLOCK_MK_CACHE,
+    TDE_LWLOCK_MK_FILES,
+
+    /* Must be the last entry in the enum */
+    TDE_LWLOCK_COUNT
+} TDELockTypes;
+
 typedef struct TDEShmemSetupRoutine
 {
     /* init_shared_state gets called at the time of extension load


### PR DESCRIPTION
Updated locking to include locks on files. This is critical to prevent parallel updates during the:
(a) map entry selection
(b) master key rotation.

The locks are essentially constructed in a 2PL phase where necessary with an outer lock for the files and the inner one for the cache.

Note that we don't need to ever acquire an exclusive lock on the keydata file as the same location can never be selected as long as we selected it via an exclusive lock on the map file.