### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Some actions in our CI workflows are outdated and produce warnings in logs. Dependabot will simplify new versions tracking and update.


Same for pg_stat_monitor: https://github.com/percona/pg_stat_monitor/pull/443