### PR TITLE
Docker: take into account POSTGRES_USER in init scripts

### DIFF
--- a/docker/pg-tde-create-ext.sh
+++ b/docker/pg-tde-create-ext.sh
@@ -2,5 +2,7 @@
 
 set -e
 
-psql -c 'CREATE EXTENSION pg_tde;'
-psql -d template1 -c 'CREATE EXTENSION pg_tde;'
+PG_USER=${POSTGRES_USER:-"postgres"}
+
+psql -U ${PG_USER} -c 'CREATE EXTENSION pg_tde;'
+psql -U ${PG_USER} -d template1 -c 'CREATE EXTENSION pg_tde;'

--- a/docker/pg-tde-streaming-repl.sh
+++ b/docker/pg-tde-streaming-repl.sh
@@ -5,10 +5,12 @@ set -e
 PG_PRIMARY=${PG_PRIMARY:-"false"}
 PG_REPLICATION=${PG_REPLICATION:-"false"}
 REPL_PASS=${REPL_PASS:-"replpass"}
+PG_USER=${POSTGRES_USER:-"postgres"}
+
 
 if [ "$PG_REPLICATION" == "true" ] ; then
   if [ "$PG_PRIMARY" == "true" ] ; then
-    psql -c "CREATE ROLE repl WITH REPLICATION PASSWORD '${REPL_PASS}' LOGIN;"
+    psql -U ${PG_USER} -c "CREATE ROLE repl WITH REPLICATION PASSWORD '${REPL_PASS}' LOGIN;"
     echo "host replication repl 0.0.0.0/0 trust" >> ${PGDATA}/pg_hba.conf
   else
     rm -rf  ${PGDATA}/*


### PR DESCRIPTION
A user may set a custom postgres super user via POSTGRES_USER but init scripts weren't aware of this and always tried to run with the default user.

Fixes https://github.com/Percona-Lab/pg_tde/discussions/193