### PR TITLE
bugfix: use raw fd to lseek

### DIFF
--- a/src/access/pg_tde_tdemap.c
+++ b/src/access/pg_tde_tdemap.c
@@ -627,7 +627,7 @@ pg_tde_process_map_entry(const RelFileLocator *rlocator, char *db_map_path, off_
 	 */
 	if (should_delete == true && *offset > 0)
 	{
-		curr_pos = lseek(map_file, *offset, SEEK_SET);
+		curr_pos = lseek(FileGetRawDesc(map_file), *offset, SEEK_SET);
 
 		if (curr_pos == -1)
 		{


### PR DESCRIPTION
map_file is vitual file descriptor, lseek should use raw fd