### PR TITLE
Update README.md - git to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ brew install make autoconf curl gettext postresql@16
 4. Clone the repository, build and install it with the following commands:  
 
 ```
-git clone git://github.com/Percona-Lab/pg_tde
+git clone https://github.com/Percona-Lab/pg_tde
 ```
 
 Compile and install the extension


### PR DESCRIPTION
spent some time figuring out why I can't pull this repo.
```
$ git clone git://github.com/Percona-Lab/pg_tde -vvv
Cloning into 'pg_tde'...
Looking up github.com ... done.
Connecting to github.com (port 9418) ... ^C
```

Switched it to https.