### PR TITLE
Rename pg_tde heap clone to tdeheap

### DIFF
--- a/src/access/pg_tde_ddl.c
+++ b/src/access/pg_tde_ddl.c
@@ -1,7 +1,7 @@
 
 /*-------------------------------------------------------------------------
  *
- * pg_tde_ddl.c
+ * tdeheap_ddl.c
  *      Handles the DDL operation on TDE relations.
  *
  * IDENTIFICATION
@@ -19,17 +19,17 @@
 
 static object_access_hook_type old_objectaccess_hook = NULL;
 
-static void pg_tde_object_access_hook(ObjectAccessType access, Oid classId,
+static void tdeheap_object_access_hook(ObjectAccessType access, Oid classId,
                                          Oid objectId, int subId, void *arg);
 
 void SetupTdeDDLHooks(void)
 {
     old_objectaccess_hook = object_access_hook;
-    object_access_hook = pg_tde_object_access_hook;
+    object_access_hook = tdeheap_object_access_hook;
 }
 
 static void
- pg_tde_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
+ tdeheap_object_access_hook(ObjectAccessType access, Oid classId, Oid objectId,
                              int subId, void *arg)
  {
      Relation    rel = NULL;
@@ -43,7 +43,7 @@ static void
         if ((rel->rd_rel->relkind == RELKIND_RELATION ||
             rel->rd_rel->relkind == RELKIND_TOASTVALUE ||
             rel->rd_rel->relkind == RELKIND_MATVIEW) &&
-            (subId == 0) && is_pg_tde_rel(rel))
+            (subId == 0) && is_tdeheap_rel(rel))
             {
                 pg_tde_delete_key_map_entry(&rel->rd_locator);
             }

--- a/src/access/pg_tde_vacuumlazy.c
+++ b/src/access/pg_tde_vacuumlazy.c
@@ -187,7 +187,7 @@ typedef struct LVRelState
 	 * dead_items stores TIDs whose index tuples are deleted by index
 	 * vacuuming. Each TID points to an LP_DEAD line pointer from a heap page
 	 * that has been processed by lazy_scan_prune.  Also needed by
-	 * lazy_vacuum_pg_tde_rel, which marks the same LP_DEAD line pointers as
+	 * lazy_vacuum_tdeheap_rel, which marks the same LP_DEAD line pointers as
 	 * LP_UNUSED during second heap pass.
 	 */
 	VacDeadItems *dead_items;	/* TIDs whose index tuples we'll delete */
@@ -260,8 +260,8 @@ static bool lazy_scan_noprune(LVRelState *vacrel, Buffer buf,
 							  bool *hastup, bool *recordfreespace);
 static void lazy_vacuum(LVRelState *vacrel);
 static bool lazy_vacuum_all_indexes(LVRelState *vacrel);
-static void lazy_vacuum_pg_tde_rel(LVRelState *vacrel);
-static int	lazy_vacuum_pg_tde_page(LVRelState *vacrel, BlockNumber blkno,
+static void lazy_vacuum_tdeheap_rel(LVRelState *vacrel);
+static int	lazy_vacuum_tdeheap_page(LVRelState *vacrel, BlockNumber blkno,
 								  Buffer buffer, int index, Buffer vmbuffer);
 static bool lazy_check_wraparound_failsafe(LVRelState *vacrel);
 static void lazy_cleanup_all_indexes(LVRelState *vacrel);
@@ -280,7 +280,7 @@ static BlockNumber count_nondeletable_pages(LVRelState *vacrel,
 											bool *lock_waiter_detected);
 static void dead_items_alloc(LVRelState *vacrel, int nworkers);
 static void dead_items_cleanup(LVRelState *vacrel);
-static bool pg_tde_page_is_all_visible(LVRelState *vacrel, Buffer buf,
+static bool tdeheap_page_is_all_visible(LVRelState *vacrel, Buffer buf,
 									 TransactionId *visibility_cutoff_xid, bool *all_frozen);
 static void update_relstats_all_indexes(LVRelState *vacrel);
 static void vacuum_error_callback(void *arg);
@@ -293,7 +293,7 @@ static void restore_vacuum_error_info(LVRelState *vacrel,
 
 
 /*
- *	pg_tde_vacuum_rel() -- perform VACUUM for one heap relation
+ *	tdeheap_vacuum_rel() -- perform VACUUM for one heap relation
  *
  *		This routine sets things up for and then calls lazy_scan_heap, where
  *		almost all work actually takes place.  Finalizes everything after call
@@ -304,7 +304,7 @@ static void restore_vacuum_error_info(LVRelState *vacrel,
  *		and locked the relation.
  */
 void
-pg_tde_vacuum_rel(Relation rel, VacuumParams *params,
+tdeheap_vacuum_rel(Relation rel, VacuumParams *params,
 				BufferAccessStrategy bstrategy)
 {
 	LVRelState *vacrel;
@@ -450,8 +450,8 @@ pg_tde_vacuum_rel(Relation rel, VacuumParams *params,
 	 * as an upper bound on the XIDs stored in the pages we'll actually scan
 	 * (NewRelfrozenXid tracking must never be allowed to miss unfrozen XIDs).
 	 *
-	 * Next acquire vistest, a related cutoff that's used in pg_tde_page_prune.
-	 * We expect vistest will always make pg_tde_page_prune remove any deleted
+	 * Next acquire vistest, a related cutoff that's used in tdeheap_page_prune.
+	 * We expect vistest will always make tdeheap_page_prune remove any deleted
 	 * tuple whose xmax is < OldestXmin.  lazy_scan_prune must never become
 	 * confused about whether a tuple should be frozen or removed.  (In the
 	 * future we might want to teach lazy_scan_prune to recompute vistest from
@@ -569,7 +569,7 @@ pg_tde_vacuum_rel(Relation rel, VacuumParams *params,
 	 * pg_class.relpages to
 	 */
 	new_rel_pages = vacrel->rel_pages;	/* After possible rel truncation */
-	pg_tde_visibilitymap_count(rel, &new_rel_allvisible, NULL);
+	tdeheap_visibilitymap_count(rel, &new_rel_allvisible, NULL);
 	if (new_rel_allvisible > new_rel_pages)
 		new_rel_allvisible = new_rel_pages;
 
@@ -801,7 +801,7 @@ pg_tde_vacuum_rel(Relation rel, VacuumParams *params,
  *		heap pages following pruning.  Earlier initial pass over the heap will
  *		have collected the TIDs whose index tuples need to be removed.
  *
- *		Finally, invokes lazy_vacuum_pg_tde_rel to vacuum heap pages, which
+ *		Finally, invokes lazy_vacuum_tdeheap_rel to vacuum heap pages, which
  *		largely consists of marking LP_DEAD items (from collected TID array)
  *		as LP_UNUSED.  This has to happen in a second, final pass over the
  *		heap, to preserve a basic invariant that all index AMs rely on: no
@@ -948,7 +948,7 @@ lazy_scan_heap(LVRelState *vacrel)
 		 * all-visible.  In most cases this will be very cheap, because we'll
 		 * already have the correct page pinned anyway.
 		 */
-		pg_tde_visibilitymap_pin(vacrel->rel, blkno, &vmbuffer);
+		tdeheap_visibilitymap_pin(vacrel->rel, blkno, &vmbuffer);
 
 		/*
 		 * We need a buffer cleanup lock to prune HOT chains and defragment
@@ -1043,7 +1043,7 @@ lazy_scan_heap(LVRelState *vacrel)
 			{
 				Size		freespace;
 
-				lazy_vacuum_pg_tde_page(vacrel, blkno, buf, 0, vmbuffer);
+				lazy_vacuum_tdeheap_page(vacrel, blkno, buf, 0, vmbuffer);
 
 				/* Forget the LP_DEAD items that we just vacuumed */
 				dead_items->num_items = 0;
@@ -1064,10 +1064,10 @@ lazy_scan_heap(LVRelState *vacrel)
 				 * Now perform FSM processing for blkno, and move on to next
 				 * page.
 				 *
-				 * Our call to lazy_vacuum_pg_tde_page() will have considered if
+				 * Our call to lazy_vacuum_tdeheap_page() will have considered if
 				 * it's possible to set all_visible/all_frozen independently
 				 * of lazy_scan_prune().  Note that prunestate was invalidated
-				 * by lazy_vacuum_pg_tde_page() call.
+				 * by lazy_vacuum_tdeheap_page() call.
 				 */
 				freespace = PageGetHeapFreeSpace(page);
 
@@ -1077,7 +1077,7 @@ lazy_scan_heap(LVRelState *vacrel)
 			}
 
 			/*
-			 * There was no call to lazy_vacuum_pg_tde_page() because pruning
+			 * There was no call to lazy_vacuum_tdeheap_page() because pruning
 			 * didn't encounter/create any LP_DEAD items that needed to be
 			 * vacuumed.  Prune state has not been invalidated, so proceed
 			 * with prunestate-driven visibility map and FSM steps (just like
@@ -1109,13 +1109,13 @@ lazy_scan_heap(LVRelState *vacrel)
 			 * NB: If the heap page is all-visible but the VM bit is not set,
 			 * we don't need to dirty the heap page.  However, if checksums
 			 * are enabled, we do need to make sure that the heap page is
-			 * dirtied before passing it to pg_tde_visibilitymap_set(), because it
+			 * dirtied before passing it to tdeheap_visibilitymap_set(), because it
 			 * may be logged.  Given that this situation should only happen in
 			 * rare cases after a crash, it is not worth optimizing.
 			 */
 			PageSetAllVisible(page);
 			MarkBufferDirty(buf);
-			pg_tde_visibilitymap_set(vacrel->rel, blkno, buf, InvalidXLogRecPtr,
+			tdeheap_visibilitymap_set(vacrel->rel, blkno, buf, InvalidXLogRecPtr,
 							  vmbuffer, prunestate.visibility_cutoff_xid,
 							  flags);
 		}
@@ -1127,11 +1127,11 @@ lazy_scan_heap(LVRelState *vacrel)
 		 * with buffer lock before concluding that the VM is corrupt.
 		 */
 		else if (all_visible_according_to_vm && !PageIsAllVisible(page) &&
-				 pg_tde_visibilitymap_get_status(vacrel->rel, blkno, &vmbuffer) != 0)
+				 tdeheap_visibilitymap_get_status(vacrel->rel, blkno, &vmbuffer) != 0)
 		{
 			elog(WARNING, "page is not marked all-visible but visibility map bit is set in relation \"%s\" page %u",
 				 vacrel->relname, blkno);
-			pg_tde_visibilitymap_clear(vacrel->rel, blkno, vmbuffer,
+			tdeheap_visibilitymap_clear(vacrel->rel, blkno, vmbuffer,
 								VISIBILITYMAP_VALID_BITS);
 		}
 
@@ -1156,7 +1156,7 @@ lazy_scan_heap(LVRelState *vacrel)
 				 vacrel->relname, blkno);
 			PageClearAllVisible(page);
 			MarkBufferDirty(buf);
-			pg_tde_visibilitymap_clear(vacrel->rel, blkno, vmbuffer,
+			tdeheap_visibilitymap_clear(vacrel->rel, blkno, vmbuffer,
 								VISIBILITYMAP_VALID_BITS);
 		}
 
@@ -1188,7 +1188,7 @@ lazy_scan_heap(LVRelState *vacrel)
 			 * safe for REDO was logged when the page's tuples were frozen.
 			 */
 			Assert(!TransactionIdIsValid(prunestate.visibility_cutoff_xid));
-			pg_tde_visibilitymap_set(vacrel->rel, blkno, buf, InvalidXLogRecPtr,
+			tdeheap_visibilitymap_set(vacrel->rel, blkno, buf, InvalidXLogRecPtr,
 							  vmbuffer, InvalidTransactionId,
 							  VISIBILITYMAP_ALL_VISIBLE |
 							  VISIBILITYMAP_ALL_FROZEN);
@@ -1201,14 +1201,14 @@ lazy_scan_heap(LVRelState *vacrel)
 		if (prunestate.has_lpdead_items && vacrel->do_index_vacuuming)
 		{
 			/*
-			 * Wait until lazy_vacuum_pg_tde_rel() to save free space.  This
+			 * Wait until lazy_vacuum_tdeheap_rel() to save free space.  This
 			 * doesn't just save us some cycles; it also allows us to record
-			 * any additional free space that lazy_vacuum_pg_tde_page() will
+			 * any additional free space that lazy_vacuum_tdeheap_page() will
 			 * make available in cases where it's possible to truncate the
 			 * page's line pointer array.
 			 *
 			 * Note: It's not in fact 100% certain that we really will call
-			 * lazy_vacuum_pg_tde_rel() -- lazy_vacuum() might yet opt to skip
+			 * lazy_vacuum_tdeheap_rel() -- lazy_vacuum() might yet opt to skip
 			 * index vacuuming (and so must skip heap vacuuming).  This is
 			 * deemed okay because it only happens in emergencies, or when
 			 * there is very little free space anyway. (Besides, we start
@@ -1306,7 +1306,7 @@ lazy_scan_skip(LVRelState *vacrel, Buffer *vmbuffer, BlockNumber next_block,
 	*next_unskippable_allvis = true;
 	while (next_unskippable_block < rel_pages)
 	{
-		uint8		mapbits = pg_tde_visibilitymap_get_status(vacrel->rel,
+		uint8		mapbits = tdeheap_visibilitymap_get_status(vacrel->rel,
 													   next_unskippable_block,
 													   vmbuffer);
 
@@ -1421,7 +1421,7 @@ lazy_scan_new_or_empty(LVRelState *vacrel, Buffer buf, BlockNumber blkno,
 		 * (which creates a number of empty pages at the tail end of the
 		 * relation), and then enters them into the FSM.
 		 *
-		 * Note we do not enter the page into the pg_tde_visibilitymap. That has the
+		 * Note we do not enter the page into the tdeheap_visibilitymap. That has the
 		 * downside that we repeatedly visit this page in subsequent vacuums,
 		 * but otherwise we'll never discover the space on a promoted standby.
 		 * The harm of repeated checking ought to normally not be too bad. The
@@ -1493,7 +1493,7 @@ lazy_scan_new_or_empty(LVRelState *vacrel, Buffer buf, BlockNumber blkno,
 				log_newpage_buffer(buf, true);
 
 			PageSetAllVisible(page);
-			pg_tde_visibilitymap_set(vacrel->rel, blkno, buf, InvalidXLogRecPtr,
+			tdeheap_visibilitymap_set(vacrel->rel, blkno, buf, InvalidXLogRecPtr,
 							  vmbuffer, InvalidTransactionId,
 							  VISIBILITYMAP_ALL_VISIBLE | VISIBILITYMAP_ALL_FROZEN);
 			END_CRIT_SECTION();
@@ -1514,16 +1514,16 @@ lazy_scan_new_or_empty(LVRelState *vacrel, Buffer buf, BlockNumber blkno,
  *
  * Caller must hold pin and buffer cleanup lock on the buffer.
  *
- * Prior to PostgreSQL 14 there were very rare cases where pg_tde_page_prune()
+ * Prior to PostgreSQL 14 there were very rare cases where tdeheap_page_prune()
  * was allowed to disagree with our HeapTupleSatisfiesVacuum() call about
  * whether or not a tuple should be considered DEAD.  This happened when an
- * inserting transaction concurrently aborted (after our pg_tde_page_prune()
+ * inserting transaction concurrently aborted (after our tdeheap_page_prune()
  * call, before our HeapTupleSatisfiesVacuum() call).  There was rather a lot
  * of complexity just so we could deal with tuples that were DEAD to VACUUM,
  * but nevertheless were left with storage after pruning.
  *
  * The approach we take now is to restart pruning when the race condition is
- * detected.  This allows pg_tde_page_prune() to prune the tuples inserted by
+ * detected.  This allows tdeheap_page_prune() to prune the tuples inserted by
  * the now-aborted transaction.  This is a little crude, but it guarantees
  * that any items that make it into the dead_items array are simple LP_DEAD
  * line pointers, and that every remaining item with tuple storage is
@@ -1557,7 +1557,7 @@ lazy_scan_prune(LVRelState *vacrel,
 
 	/*
 	 * maxoff might be reduced following line pointer array truncation in
-	 * pg_tde_page_prune.  That's safe for us to ignore, since the reclaimed
+	 * tdeheap_page_prune.  That's safe for us to ignore, since the reclaimed
 	 * space will continue to look like LP_UNUSED items below.
 	 */
 	maxoff = PageGetMaxOffsetNumber(page);
@@ -1585,7 +1585,7 @@ retry:
 	 * lpdead_items's final value can be thought of as the number of tuples
 	 * that were deleted from indexes.
 	 */
-	tuples_deleted = pg_tde_page_prune(rel, buf, vacrel->vistest,
+	tuples_deleted = tdeheap_page_prune(rel, buf, vacrel->vistest,
 									 InvalidTransactionId, 0, &nnewlpdead,
 									 &vacrel->offnum);
 
@@ -1652,8 +1652,8 @@ retry:
 
 		/*
 		 * DEAD tuples are almost always pruned into LP_DEAD line pointers by
-		 * pg_tde_page_prune(), but it's possible that the tuple state changed
-		 * since pg_tde_page_prune() looked.  Handle that here by restarting.
+		 * tdeheap_page_prune(), but it's possible that the tuple state changed
+		 * since tdeheap_page_prune() looked.  Handle that here by restarting.
 		 * (See comments at the top of function for a full explanation.)
 		 */
 		res = HeapTupleSatisfiesVacuum(&tuple, vacrel->cutoffs.OldestXmin,
@@ -1767,7 +1767,7 @@ retry:
 		prunestate->hastup = true;	/* page makes rel truncation unsafe */
 
 		/* Tuple with storage -- consider need to freeze */
-		if (pg_tde_prepare_freeze_tuple(tuple.t_data, &vacrel->cutoffs, &pagefrz,
+		if  (tdeheap_prepare_freeze_tuple(tuple.t_data, &vacrel->cutoffs, &pagefrz,
 									  &frozen[tuples_frozen], &totally_frozen))
 		{
 			/* Save prepared freeze plan for later */
@@ -1792,7 +1792,7 @@ retry:
 	vacrel->offnum = InvalidOffsetNumber;
 
 	/*
-	 * Freeze the page when pg_tde_prepare_freeze_tuple indicates that at least
+	 * Freeze the page when tdeheap_prepare_freeze_tuple indicates that at least
 	 * one XID/MXID from before FreezeLimit/MultiXactCutoff is present.  Also
 	 * freeze when pruning generated an FPI, if doing so means that we set the
 	 * page all-frozen afterwards (might not happen until final heap pass).
@@ -1850,7 +1850,7 @@ retry:
 			}
 
 			/* Execute all freeze plans for page as a single atomic action */
-			pg_tde_freeze_execute_prepared(vacrel->rel, buf,
+			tdeheap_freeze_execute_prepared(vacrel->rel, buf,
 										 snapshotConflictHorizon,
 										 frozen, tuples_frozen);
 		}
@@ -1868,11 +1868,11 @@ retry:
 	}
 
 	/*
-	 * VACUUM will call pg_tde_page_is_all_visible() during the second pass over
+	 * VACUUM will call tdeheap_page_is_all_visible() during the second pass over
 	 * the heap to determine all_visible and all_frozen for the page -- this
 	 * is a specialized version of the logic from this function.  Now that
 	 * we've finished pruning and freezing, make sure that we're in total
-	 * agreement with pg_tde_page_is_all_visible() using an assertion.
+	 * agreement with tdeheap_page_is_all_visible() using an assertion.
 	 */
 #ifdef USE_ASSERT_CHECKING
 	/* Note that all_frozen value does not matter when !all_visible */
@@ -1881,7 +1881,7 @@ retry:
 		TransactionId cutoff;
 		bool		all_frozen;
 
-		if (!pg_tde_page_is_all_visible(vacrel, buf, &cutoff, &all_frozen))
+		if (!tdeheap_page_is_all_visible(vacrel, buf, &cutoff, &all_frozen))
 			Assert(false);
 
 		Assert(!TransactionIdIsValid(cutoff) ||
@@ -2015,7 +2015,7 @@ lazy_scan_noprune(LVRelState *vacrel,
 		*hastup = true;			/* page prevents rel truncation */
 		tupleheader = (HeapTupleHeader) PageGetItem(page, itemid);
 		// TODO: decrypt
-		if (pg_tde_tuple_should_freeze(tupleheader, &vacrel->cutoffs,
+		if  (tdeheap_tuple_should_freeze(tupleheader, &vacrel->cutoffs,
 									 &NoFreezePageRelfrozenXid,
 									 &NoFreezePageRelminMxid))
 		{
@@ -2280,7 +2280,7 @@ lazy_vacuum(LVRelState *vacrel)
 		 * We successfully completed a round of index vacuuming.  Do related
 		 * heap vacuuming now.
 		 */
-		lazy_vacuum_pg_tde_rel(vacrel);
+		lazy_vacuum_tdeheap_rel(vacrel);
 	}
 	else
 	{
@@ -2370,7 +2370,7 @@ lazy_vacuum_all_indexes(LVRelState *vacrel)
 	/*
 	 * We delete all LP_DEAD items from the first heap pass in all indexes on
 	 * each call here (except calls where we choose to do the failsafe). This
-	 * makes the next call to lazy_vacuum_pg_tde_rel() safe (except in the event
+	 * makes the next call to lazy_vacuum_tdeheap_rel() safe (except in the event
 	 * of the failsafe triggering, which prevents the next call from taking
 	 * place).
 	 */
@@ -2392,7 +2392,7 @@ lazy_vacuum_all_indexes(LVRelState *vacrel)
 }
 
 /*
- *	lazy_vacuum_pg_tde_rel() -- second pass over the heap for two pass strategy
+ *	lazy_vacuum_tdeheap_rel() -- second pass over the heap for two pass strategy
  *
  * This routine marks LP_DEAD items in vacrel->dead_items array as LP_UNUSED.
  * Pages that never had lazy_scan_prune record LP_DEAD items are not visited
@@ -2410,7 +2410,7 @@ lazy_vacuum_all_indexes(LVRelState *vacrel)
  * index entry removal in batches as large as possible.
  */
 static void
-lazy_vacuum_pg_tde_rel(LVRelState *vacrel)
+lazy_vacuum_tdeheap_rel(LVRelState *vacrel)
 {
 	int			index = 0;
 	BlockNumber vacuumed_pages = 0;
@@ -2447,13 +2447,13 @@ lazy_vacuum_pg_tde_rel(LVRelState *vacrel)
 		 * all-visible.  In most cases this will be very cheap, because we'll
 		 * already have the correct page pinned anyway.
 		 */
-		pg_tde_visibilitymap_pin(vacrel->rel, blkno, &vmbuffer);
+		tdeheap_visibilitymap_pin(vacrel->rel, blkno, &vmbuffer);
 
 		/* We need a non-cleanup exclusive lock to mark dead_items unused */
 		buf = ReadBufferExtended(vacrel->rel, MAIN_FORKNUM, blkno, RBM_NORMAL,
 								 vacrel->bstrategy);
 		LockBuffer(buf, BUFFER_LOCK_EXCLUSIVE);
-		index = lazy_vacuum_pg_tde_page(vacrel, blkno, buf, index, vmbuffer);
+		index = lazy_vacuum_tdeheap_page(vacrel, blkno, buf, index, vmbuffer);
 
 		/* Now that we've vacuumed the page, record its available space */
 		page = BufferGetPage(buf);
@@ -2486,7 +2486,7 @@ lazy_vacuum_pg_tde_rel(LVRelState *vacrel)
 }
 
 /*
- *	lazy_vacuum_pg_tde_page() -- free page's LP_DEAD items listed in the
+ *	lazy_vacuum_tdeheap_page() -- free page's LP_DEAD items listed in the
  *						  vacrel->dead_items array.
  *
  * Caller must have an exclusive buffer lock on the buffer (though a full
@@ -2498,7 +2498,7 @@ lazy_vacuum_pg_tde_rel(LVRelState *vacrel)
  * after all LP_DEAD items for the same page in the array.
  */
 static int
-lazy_vacuum_pg_tde_page(LVRelState *vacrel, BlockNumber blkno, Buffer buffer,
+lazy_vacuum_tdeheap_page(LVRelState *vacrel, BlockNumber blkno, Buffer buffer,
 					  int index, Buffer vmbuffer)
 {
 	VacDeadItems *dead_items = vacrel->dead_items;
@@ -2550,7 +2550,7 @@ lazy_vacuum_pg_tde_page(LVRelState *vacrel, BlockNumber blkno, Buffer buffer,
 	/* XLOG stuff */
 	if (RelationNeedsWAL(vacrel->rel))
 	{
-		xl_pg_tde_vacuum xlrec;
+		xl_tdeheap_vacuum xlrec;
 		XLogRecPtr	recptr;
 
 		xlrec.nunused = nunused;
@@ -2581,7 +2581,7 @@ lazy_vacuum_pg_tde_page(LVRelState *vacrel, BlockNumber blkno, Buffer buffer,
 	 * emitted.
 	 */
 	Assert(!PageIsAllVisible(page));
-	if (pg_tde_page_is_all_visible(vacrel, buffer, &visibility_cutoff_xid,
+	if  (tdeheap_page_is_all_visible(vacrel, buffer, &visibility_cutoff_xid,
 								 &all_frozen))
 	{
 		uint8		flags = VISIBILITYMAP_ALL_VISIBLE;
@@ -2593,7 +2593,7 @@ lazy_vacuum_pg_tde_page(LVRelState *vacrel, BlockNumber blkno, Buffer buffer,
 		}
 
 		PageSetAllVisible(page);
-		pg_tde_visibilitymap_set(vacrel->rel, blkno, buffer, InvalidXLogRecPtr,
+		tdeheap_visibilitymap_set(vacrel->rel, blkno, buffer, InvalidXLogRecPtr,
 						  vmbuffer, visibility_cutoff_xid, flags);
 	}
 
@@ -3237,7 +3237,7 @@ dead_items_cleanup(LVRelState *vacrel)
  * introducing new side-effects here.
  */
 static bool
-pg_tde_page_is_all_visible(LVRelState *vacrel, Buffer buf,
+tdeheap_page_is_all_visible(LVRelState *vacrel, Buffer buf,
 						 TransactionId *visibility_cutoff_xid,
 						 bool *all_frozen)
 {
@@ -3323,7 +3323,7 @@ pg_tde_page_is_all_visible(LVRelState *vacrel, Buffer buf,
 
 					/* Check whether this tuple is already frozen or not */
 					if (all_visible && *all_frozen &&
-						pg_tde_tuple_needs_eventual_freeze(tuple.t_data))
+						tdeheap_tuple_needs_eventual_freeze(tuple.t_data))
 						*all_frozen = false;
 				}
 				break;

--- a/src/access/pg_tde_xlog.c
+++ b/src/access/pg_tde_xlog.c
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * pg_tde_xlog.c
+ * tdeheap_xlog.c
  *	  TDE XLog resource manager
  *
  *
@@ -45,7 +45,7 @@ static int XLOGChooseNumBuffers(void);
  * TDE fork XLog
  */
 void
-pg_tde_rmgr_redo(XLogReaderState *record)
+tdeheap_rmgr_redo(XLogReaderState *record)
 {
 	uint8		info = XLogRecGetInfo(record) & ~XLR_INFO_MASK;
 
@@ -80,7 +80,7 @@ pg_tde_rmgr_redo(XLogReaderState *record)
 }
 
 void
-pg_tde_rmgr_desc(StringInfo buf, XLogReaderState *record)
+tdeheap_rmgr_desc(StringInfo buf, XLogReaderState *record)
 {
 	uint8		info = XLogRecGetInfo(record) & ~XLR_INFO_MASK;
 
@@ -111,7 +111,7 @@ pg_tde_rmgr_desc(StringInfo buf, XLogReaderState *record)
 }
 
 const char *
-pg_tde_rmgr_identify(uint8 info)
+tdeheap_rmgr_identify(uint8 info)
 {
 	if ((info & ~XLR_INFO_MASK) == XLOG_TDE_ADD_RELATION_KEY)
 		return "XLOG_TDE_ADD_RELATION_KEY";
@@ -177,7 +177,7 @@ TDEXLogEncryptBuffSize(void)
  * Alloc memory for the encryption buffer.
  * 
  * It should fit XLog buffers (XLOG_BLCKSZ * wal_buffers). We can't
- * (re)alloc this buf in pg_tde_xlog_seg_write() based on the write size as
+ * (re)alloc this buf in tdeheap_xlog_seg_write() based on the write size as
  * it's called in the CRIT section, hence no allocations are allowed.
  * 
  * Access to this buffer happens during XLogWrite() call which should
@@ -207,7 +207,7 @@ TDEXLogSmgrInit(void)
 }
 
 ssize_t
-pg_tde_xlog_seg_write(int fd, const void *buf, size_t count, off_t offset)
+tdeheap_xlog_seg_write(int fd, const void *buf, size_t count, off_t offset)
 {
 	if (EncryptXLog)
 		return TDEXLogWriteEncryptedPages(fd, buf, count, offset);
@@ -306,7 +306,7 @@ TDEXLogWriteEncryptedPages(int fd, const void *buf, size_t count, off_t offset)
  * Read the XLog pages from the segment file and dectypt if need.
  */
 ssize_t
-pg_tde_xlog_seg_read(int fd, void *buf, size_t count, off_t offset)
+tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset)
 {
 	ssize_t readsz;
 	char	iv_prefix[16] = {0,};

--- a/src/access/pg_tdetoast.c
+++ b/src/access/pg_tdetoast.c
@@ -12,11 +12,11 @@
  *
  *
  * INTERFACE ROUTINES
- *		pg_tde_toast_insert_or_update -
+ *		tdeheap_toast_insert_or_update -
  *			Try to make a given tuple fit into one page by compressing
  *			or moving off attributes
  *
- *		pg_tde_toast_delete -
+ *		tdeheap_toast_delete -
  *			Reclaim toast storage when a tuple is deleted
  *
  *-------------------------------------------------------------------------
@@ -39,24 +39,24 @@
 
 #define TDE_TOAST_COMPRESS_HEADER_SIZE (VARHDRSZ_COMPRESSED - VARHDRSZ)
 
-static void pg_tde_toast_tuple_externalize(ToastTupleContext *ttc,
+static void tdeheap_toast_tuple_externalize(ToastTupleContext *ttc,
 									int attribute, int options);
-static Datum pg_tde_toast_save_datum(Relation rel, Datum value,
+static Datum tdeheap_toast_save_datum(Relation rel, Datum value,
 								struct varlena *oldexternal,
 								int options);
-static void pg_tde_toast_encrypt(Pointer dval, Oid valueid, RelKeyData *keys);
+static void tdeheap_toast_encrypt(Pointer dval, Oid valueid, RelKeyData *keys);
 static bool toastrel_valueid_exists(Relation toastrel, Oid valueid);
 static bool toastid_valueid_exists(Oid toastrelid, Oid valueid);
 
 
 /* ----------
- * pg_tde_toast_delete -
+ * tdeheap_toast_delete -
  *
  *	Cascaded delete toast-entries on DELETE
  * ----------
  */
 void
-pg_tde_toast_delete(Relation rel, HeapTuple oldtup, bool is_speculative)
+tdeheap_toast_delete(Relation rel, HeapTuple oldtup, bool is_speculative)
 {
 	TupleDesc	tupleDesc;
 	Datum		toast_values[MaxHeapAttributeNumber];
@@ -72,10 +72,10 @@ pg_tde_toast_delete(Relation rel, HeapTuple oldtup, bool is_speculative)
 	/*
 	 * Get the tuple descriptor and break down the tuple into fields.
 	 *
-	 * NOTE: it's debatable whether to use pg_tde_deform_tuple() here or just
-	 * pg_tde_getattr() only the varlena columns.  The latter could win if there
+	 * NOTE: it's debatable whether to use tdeheap_deform_tuple() here or just
+	 * tdeheap_getattr() only the varlena columns.  The latter could win if there
 	 * are few varlena columns and many non-varlena ones. However,
-	 * pg_tde_deform_tuple costs only O(N) while the pg_tde_getattr way would cost
+	 * tdeheap_deform_tuple costs only O(N) while the tdeheap_getattr way would cost
 	 * O(N^2) if there are many varlena columns, so it seems better to err on
 	 * the side of linear cost.  (We won't even be here unless there's at
 	 * least one varlena column, by the way.)
@@ -83,7 +83,7 @@ pg_tde_toast_delete(Relation rel, HeapTuple oldtup, bool is_speculative)
 	tupleDesc = rel->rd_att;
 
 	Assert(tupleDesc->natts <= MaxHeapAttributeNumber);
-	pg_tde_deform_tuple(oldtup, tupleDesc, toast_values, toast_isnull);
+	tdeheap_deform_tuple(oldtup, tupleDesc, toast_values, toast_isnull);
 
 	/* Do the real work. */
 	toast_delete_external(rel, toast_values, toast_isnull, is_speculative);
@@ -91,7 +91,7 @@ pg_tde_toast_delete(Relation rel, HeapTuple oldtup, bool is_speculative)
 
 
 /* ----------
- * pg_tde_toast_insert_or_update -
+ * tdeheap_toast_insert_or_update -
  *
  *	Delete no-longer-used toast-entries and create new ones to
  *	make the new tuple fit on INSERT or UPDATE
@@ -99,7 +99,7 @@ pg_tde_toast_delete(Relation rel, HeapTuple oldtup, bool is_speculative)
  * Inputs:
  *	newtup: the candidate new tuple to be inserted
  *	oldtup: the old row version for UPDATE, or NULL for INSERT
- *	options: options to be passed to pg_tde_insert() for toast rows
+ *	options: options to be passed to tdeheap_insert() for toast rows
  * Result:
  *	either newtup if no toasting is needed, or a palloc'd modified tuple
  *	that is what should actually get stored
@@ -109,7 +109,7 @@ pg_tde_toast_delete(Relation rel, HeapTuple oldtup, bool is_speculative)
  * ----------
  */
 HeapTuple
-pg_tde_toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
+tdeheap_toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 							int options)
 {
 	HeapTuple	result_tuple;
@@ -148,9 +148,9 @@ pg_tde_toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 	numAttrs = tupleDesc->natts;
 
 	Assert(numAttrs <= MaxHeapAttributeNumber);
-	pg_tde_deform_tuple(newtup, tupleDesc, toast_values, toast_isnull);
+	tdeheap_deform_tuple(newtup, tupleDesc, toast_values, toast_isnull);
 	if (oldtup != NULL)
-		pg_tde_deform_tuple(oldtup, tupleDesc, toast_oldvalues, toast_oldisnull);
+		tdeheap_deform_tuple(oldtup, tupleDesc, toast_oldvalues, toast_oldisnull);
 
 	/* ----------
 	 * Prepare for toasting
@@ -184,7 +184,7 @@ pg_tde_toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 	 * ----------
 	 */
 
-	/* compute header overhead --- this should match pg_tde_form_tuple() */
+	/* compute header overhead --- this should match tdeheap_form_tuple() */
 	hoff = SizeofHeapTupleHeader;
 	if ((ttc.ttc_flags & TOAST_HAS_NULLS) != 0)
 		hoff += BITMAPLEN(numAttrs);
@@ -197,7 +197,7 @@ pg_tde_toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 	 * large attributes with attstorage EXTENDED or EXTERNAL, and store them
 	 * external.
 	 */
-	while (pg_tde_compute_data_size(tupleDesc,
+	while  (tdeheap_compute_data_size(tupleDesc,
 								  toast_values, toast_isnull) > maxDataLen)
 	{
 		int			biggest_attno;
@@ -230,7 +230,7 @@ pg_tde_toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 		 */
 		if (toast_attr[biggest_attno].tai_size > maxDataLen &&
 			rel->rd_rel->reltoastrelid != InvalidOid)
-			pg_tde_toast_tuple_externalize(&ttc, biggest_attno, options);
+			tdeheap_toast_tuple_externalize(&ttc, biggest_attno, options);
 	}
 
 	/*
@@ -238,7 +238,7 @@ pg_tde_toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 	 * are still inline, and make them external.  But skip this if there's no
 	 * toast table to push them to.
 	 */
-	while (pg_tde_compute_data_size(tupleDesc,
+	while  (tdeheap_compute_data_size(tupleDesc,
 								  toast_values, toast_isnull) > maxDataLen &&
 		   rel->rd_rel->reltoastrelid != InvalidOid)
 	{
@@ -247,14 +247,14 @@ pg_tde_toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 		biggest_attno = toast_tuple_find_biggest_attribute(&ttc, false, false);
 		if (biggest_attno < 0)
 			break;
-		pg_tde_toast_tuple_externalize(&ttc, biggest_attno, options);
+		tdeheap_toast_tuple_externalize(&ttc, biggest_attno, options);
 	}
 
 	/*
 	 * Round 3 - this time we take attributes with storage MAIN into
 	 * compression
 	 */
-	while (pg_tde_compute_data_size(tupleDesc,
+	while  (tdeheap_compute_data_size(tupleDesc,
 								  toast_values, toast_isnull) > maxDataLen)
 	{
 		int			biggest_attno;
@@ -273,7 +273,7 @@ pg_tde_toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 	 */
 	maxDataLen = TOAST_TUPLE_TARGET_MAIN - hoff;
 
-	while (pg_tde_compute_data_size(tupleDesc,
+	while  (tdeheap_compute_data_size(tupleDesc,
 								  toast_values, toast_isnull) > maxDataLen &&
 		   rel->rd_rel->reltoastrelid != InvalidOid)
 	{
@@ -283,7 +283,7 @@ pg_tde_toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 		if (biggest_attno < 0)
 			break;
 
-		pg_tde_toast_tuple_externalize(&ttc, biggest_attno, options);
+		tdeheap_toast_tuple_externalize(&ttc, biggest_attno, options);
 	}
 
 	/*
@@ -312,7 +312,7 @@ pg_tde_toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 		if ((ttc.ttc_flags & TOAST_HAS_NULLS) != 0)
 			new_header_len += BITMAPLEN(numAttrs);
 		new_header_len = MAXALIGN(new_header_len);
-		new_data_len = pg_tde_compute_data_size(tupleDesc,
+		new_data_len = tdeheap_compute_data_size(tupleDesc,
 											  toast_values, toast_isnull);
 		new_tuple_len = new_header_len + new_data_len;
 
@@ -334,7 +334,7 @@ pg_tde_toast_insert_or_update(Relation rel, HeapTuple newtup, HeapTuple oldtup,
 		new_data->t_hoff = new_header_len;
 
 		/* Copy over the data, and fill the null bitmap if needed */
-		pg_tde_fill_tuple(tupleDesc,
+		tdeheap_fill_tuple(tupleDesc,
 						toast_values,
 						toast_isnull,
 						(char *) new_data + new_header_len,
@@ -376,7 +376,7 @@ toast_flatten_tuple(HeapTuple tup, TupleDesc tupleDesc)
 	 * Break down the tuple into fields.
 	 */
 	Assert(numAttrs <= MaxTupleAttributeNumber);
-	pg_tde_deform_tuple(tup, tupleDesc, toast_values, toast_isnull);
+	tdeheap_deform_tuple(tup, tupleDesc, toast_values, toast_isnull);
 
 	memset(toast_free, 0, numAttrs * sizeof(bool));
 
@@ -402,7 +402,7 @@ toast_flatten_tuple(HeapTuple tup, TupleDesc tupleDesc)
 	/*
 	 * Form the reconfigured tuple.
 	 */
-	new_tuple = pg_tde_form_tuple(tupleDesc, toast_values, toast_isnull);
+	new_tuple = tdeheap_form_tuple(tupleDesc, toast_values, toast_isnull);
 
 	/*
 	 * Be sure to copy the tuple's identity fields.  We also make a point of
@@ -458,7 +458,7 @@ toast_flatten_tuple(HeapTuple tup, TupleDesc tupleDesc)
  *
  *	On the other hand, in-line short-header varlena fields are left alone.
  *	If we "untoasted" them here, they'd just get changed back to short-header
- *	format anyway within pg_tde_fill_tuple.
+ *	format anyway within tdeheap_fill_tuple.
  * ----------
  */
 Datum
@@ -488,7 +488,7 @@ toast_flatten_tuple_to_datum(HeapTupleHeader tup,
 	 * Break down the tuple into fields.
 	 */
 	Assert(numAttrs <= MaxTupleAttributeNumber);
-	pg_tde_deform_tuple(&tmptup, tupleDesc, toast_values, toast_isnull);
+	tdeheap_deform_tuple(&tmptup, tupleDesc, toast_values, toast_isnull);
 
 	memset(toast_free, 0, numAttrs * sizeof(bool));
 
@@ -518,13 +518,13 @@ toast_flatten_tuple_to_datum(HeapTupleHeader tup,
 	 * Calculate the new size of the tuple.
 	 *
 	 * This should match the reconstruction code in
-	 * pg_tde_toast_insert_or_update.
+	 * tdeheap_toast_insert_or_update.
 	 */
 	new_header_len = SizeofHeapTupleHeader;
 	if (has_nulls)
 		new_header_len += BITMAPLEN(numAttrs);
 	new_header_len = MAXALIGN(new_header_len);
-	new_data_len = pg_tde_compute_data_size(tupleDesc,
+	new_data_len = tdeheap_compute_data_size(tupleDesc,
 										  toast_values, toast_isnull);
 	new_tuple_len = new_header_len + new_data_len;
 
@@ -543,7 +543,7 @@ toast_flatten_tuple_to_datum(HeapTupleHeader tup,
 	HeapTupleHeaderSetTypMod(new_data, tupleDesc->tdtypmod);
 
 	/* Copy over the data, and fill the null bitmap if needed */
-	pg_tde_fill_tuple(tupleDesc,
+	tdeheap_fill_tuple(tupleDesc,
 					toast_values,
 					toast_isnull,
 					(char *) new_data + new_header_len,
@@ -568,7 +568,7 @@ toast_flatten_tuple_to_datum(HeapTupleHeader tup,
  *	Build a tuple containing no out-of-line toasted fields.
  *	(This does not eliminate compressed or short-header datums.)
  *
- *	This is essentially just like pg_tde_form_tuple, except that it will
+ *	This is essentially just like tdeheap_form_tuple, except that it will
  *	expand any external-data pointers beforehand.
  *
  *	It's not very clear whether it would be preferable to decompress
@@ -588,7 +588,7 @@ toast_build_flattened_tuple(TupleDesc tupleDesc,
 	Pointer		freeable_values[MaxTupleAttributeNumber];
 
 	/*
-	 * We can pass the caller's isnull array directly to pg_tde_form_tuple, but
+	 * We can pass the caller's isnull array directly to tdeheap_form_tuple, but
 	 * we potentially need to modify the values array.
 	 */
 	Assert(numAttrs <= MaxTupleAttributeNumber);
@@ -617,7 +617,7 @@ toast_build_flattened_tuple(TupleDesc tupleDesc,
 	/*
 	 * Form the reconfigured tuple.
 	 */
-	new_tuple = pg_tde_form_tuple(tupleDesc, new_values, isnull);
+	new_tuple = tdeheap_form_tuple(tupleDesc, new_values, isnull);
 
 	/*
 	 * Free allocated temp values
@@ -639,7 +639,7 @@ toast_build_flattened_tuple(TupleDesc tupleDesc,
  * result is the varlena into which the results should be written.
  */
 void
-pg_tde_fetch_toast_slice(Relation toastrel, Oid valueid, int32 attrsize,
+tdeheap_fetch_toast_slice(Relation toastrel, Oid valueid, int32 attrsize,
 					   int32 sliceoffset, int32 slicelength,
 					   struct varlena *result)
 {
@@ -744,7 +744,7 @@ pg_tde_fetch_toast_slice(Relation toastrel, Oid valueid, int32 attrsize,
 		}
 		else if (VARATT_IS_SHORT(chunk))
 		{
-			/* could happen due to pg_tde_form_tuple doing its thing */
+			/* could happen due to tdeheap_form_tuple doing its thing */
 			chunksize = VARSIZE_SHORT(chunk) - VARHDRSZ_SHORT;
 			chunkdata = VARDATA_SHORT(chunk);
 		}
@@ -843,7 +843,7 @@ pg_tde_fetch_toast_slice(Relation toastrel, Oid valueid, int32 attrsize,
 
 /* pg_tde extension */
 static void
-pg_tde_toast_encrypt(Pointer dval, Oid valueid, RelKeyData *key)
+tdeheap_toast_encrypt(Pointer dval, Oid valueid, RelKeyData *key)
 {
 	int32		data_size =0;
 	char*		data_p;
@@ -886,14 +886,14 @@ pg_tde_toast_encrypt(Pointer dval, Oid valueid, RelKeyData *key)
  * copy from PG src/backend/access/table/toast_helper.c
  */
 static void
-pg_tde_toast_tuple_externalize(ToastTupleContext *ttc, int attribute, int options)
+tdeheap_toast_tuple_externalize(ToastTupleContext *ttc, int attribute, int options)
 {
 	Datum	   *value = &ttc->ttc_values[attribute];
 	Datum		old_value = *value;
 	ToastAttrInfo *attr = &ttc->ttc_attr[attribute];
 
 	attr->tai_colflags |= TOASTCOL_IGNORE;
-	*value = pg_tde_toast_save_datum(ttc->ttc_rel, old_value, attr->tai_oldexternal,
+	*value = tdeheap_toast_save_datum(ttc->ttc_rel, old_value, attr->tai_oldexternal,
 							  options);
 	if ((attr->tai_colflags & TOASTCOL_NEEDS_FREE) != 0)
 		pfree(DatumGetPointer(old_value));
@@ -902,7 +902,7 @@ pg_tde_toast_tuple_externalize(ToastTupleContext *ttc, int attribute, int option
 }
 
 /* ----------
- * pg_tde_toast_save_datum -
+ * tdeheap_toast_save_datum -
  *
  *	Save one single datum into the secondary relation and return
  *	a Datum reference for it.
@@ -911,13 +911,13 @@ pg_tde_toast_tuple_externalize(ToastTupleContext *ttc, int attribute, int option
  * rel: the main relation we're working with (not the toast rel!)
  * value: datum to be pushed to toast storage
  * oldexternal: if not NULL, toast pointer previously representing the datum
- * options: options to be passed to heap_insert() for toast rows
+ * options: options to be passed to tdeheap_insert() for toast rows
  * 
  * based on toast_save_datum from PG src/backend/access/common/toast_internals.c
  * ----------
  */
 static Datum
-pg_tde_toast_save_datum(Relation rel, Datum value,
+tdeheap_toast_save_datum(Relation rel, Datum value,
 				 struct varlena *oldexternal, int options)
 {
 	Relation	toastrel;
@@ -1094,7 +1094,7 @@ pg_tde_toast_save_datum(Relation rel, Datum value,
 	/*
 	* Encrypt toast data.
 	*/
-	pg_tde_toast_encrypt(dval, toast_pointer.va_valueid, GetRelationKey(toastrel->rd_locator));
+	tdeheap_toast_encrypt(dval, toast_pointer.va_valueid, GetRelationKey(toastrel->rd_locator));
 
 	/*
 	 * Initialize constant parts of the tuple data
@@ -1125,14 +1125,14 @@ pg_tde_toast_save_datum(Relation rel, Datum value,
 		t_values[1] = Int32GetDatum(chunk_seq++);
 		SET_VARSIZE(&chunk_data, chunk_size + VARHDRSZ);
 		memcpy(VARDATA(&chunk_data), data_p, chunk_size);
-		toasttup = heap_form_tuple(toasttupDesc, t_values, t_isnull);
+		toasttup = tdeheap_form_tuple(toasttupDesc, t_values, t_isnull);
 
 		/*
 		 * The tuple should be insterted not encrypted.
 		 * TOAST data already encrypted.
 		 */
 		options |= HEAP_INSERT_TDE_NO_ENCRYPT;
-		pg_tde_insert(toastrel, toasttup, mycid, options, NULL);
+		tdeheap_insert(toastrel, toasttup, mycid, options, NULL);
 
 		/*
 		 * Create the index entry.  We cheat a little here by not using
@@ -1160,7 +1160,7 @@ pg_tde_toast_save_datum(Relation rel, Datum value,
 		/*
 		 * Free memory
 		 */
-		heap_freetuple(toasttup);
+		tdeheap_freetuple(toasttup);
 
 		/*
 		 * Move on to next chunk

--- a/src/include/access/pg_tde_ddl.h
+++ b/src/include/access/pg_tde_ddl.h
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * pg_tde_ddl.h
+ * tdeheap_ddl.h
  *
  * Portions Copyright (c) 1996-2023, PostgreSQL Global Development Group
  * Portions Copyright (c) 1994, Regents of the University of California

--- a/src/include/access/pg_tde_io.h
+++ b/src/include/access/pg_tde_io.h
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * pg_tde_io.h
+ * tdeheap_io.h
  *	  POSTGRES heap access method input/output definitions.
  *
  *
@@ -51,9 +51,9 @@ typedef struct BulkInsertStateData
 } BulkInsertStateData;
 
 
-extern void pg_tde_RelationPutHeapTuple(Relation relation, Buffer buffer,
+extern void tdeheap_RelationPutHeapTuple(Relation relation, Buffer buffer,
 								 HeapTuple tuple, bool encrypt, bool token);
-extern Buffer pg_tde_RelationGetBufferForTuple(Relation relation, Size len,
+extern Buffer tdeheap_RelationGetBufferForTuple(Relation relation, Size len,
 										Buffer otherBuffer, int options,
 										BulkInsertStateData *bistate,
 										Buffer *vmbuffer, Buffer *vmbuffer_other,

--- a/src/include/access/pg_tde_rewrite.h
+++ b/src/include/access/pg_tde_rewrite.h
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * pg_tde_rewrite.h
+ * tdeheap_rewrite.h
  *	  Declarations for heap rewrite support functions
  *
  * Portions Copyright (c) 1996-2023, PostgreSQL Global Development Group
@@ -21,13 +21,13 @@
 /* struct definition is private to rewriteheap.c */
 typedef struct RewriteStateData *RewriteState;
 
-extern RewriteState begin_pg_tde_rewrite(Relation old_heap, Relation new_heap,
+extern RewriteState begin_tdeheap_rewrite(Relation old_heap, Relation new_heap,
 									   TransactionId oldest_xmin, TransactionId freeze_xid,
 									   MultiXactId cutoff_multi);
-extern void end_pg_tde_rewrite(RewriteState state);
-extern void rewrite_pg_tde_tuple(RewriteState state, HeapTuple old_tuple,
+extern void end_tdeheap_rewrite(RewriteState state);
+extern void rewrite_tdeheap_tuple(RewriteState state, HeapTuple old_tuple,
 							   HeapTuple new_tuple);
-extern bool rewrite_pg_tde_dead_tuple(RewriteState state, HeapTuple old_tuple);
+extern bool rewrite_tdeheap_dead_tuple(RewriteState state, HeapTuple old_tuple);
 
 /*
  * On-Disk data format for an individual logical rewrite mapping.

--- a/src/include/access/pg_tde_slot.h
+++ b/src/include/access/pg_tde_slot.h
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * pg_tde_slot.h
+ * tdeheap_slot.h
  *	  TupleSlot implementation for TDE
  *
  * src/include/access/pg_tde_slot.h

--- a/src/include/access/pg_tde_visibilitymap.h
+++ b/src/include/access/pg_tde_visibilitymap.h
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * pg_tde_visibilitymap.h
+ * tdeheap_visibilitymap.h
  *		visibility map interface
  *
  *
@@ -20,23 +20,23 @@
 #include "storage/buf.h"
 #include "utils/relcache.h"
 
-/* Macros for pg_tde_visibilitymap test */
+/* Macros for tdeheap_visibilitymap test */
 #define VM_ALL_VISIBLE(r, b, v) \
-	((pg_tde_visibilitymap_get_status((r), (b), (v)) & VISIBILITYMAP_ALL_VISIBLE) != 0)
+	( (tdeheap_visibilitymap_get_status((r), (b), (v)) & VISIBILITYMAP_ALL_VISIBLE) != 0)
 #define VM_ALL_FROZEN(r, b, v) \
-	((pg_tde_visibilitymap_get_status((r), (b), (v)) & VISIBILITYMAP_ALL_FROZEN) != 0)
+	( (tdeheap_visibilitymap_get_status((r), (b), (v)) & VISIBILITYMAP_ALL_FROZEN) != 0)
 
-extern bool pg_tde_visibilitymap_clear(Relation rel, BlockNumber heapBlk,
+extern bool tdeheap_visibilitymap_clear(Relation rel, BlockNumber heapBlk,
 								Buffer vmbuf, uint8 flags);
-extern void pg_tde_visibilitymap_pin(Relation rel, BlockNumber heapBlk,
+extern void tdeheap_visibilitymap_pin(Relation rel, BlockNumber heapBlk,
 							  Buffer *vmbuf);
-extern bool pg_tde_visibilitymap_pin_ok(BlockNumber heapBlk, Buffer vmbuf);
-extern void pg_tde_visibilitymap_set(Relation rel, BlockNumber heapBlk, Buffer heapBuf,
+extern bool tdeheap_visibilitymap_pin_ok(BlockNumber heapBlk, Buffer vmbuf);
+extern void tdeheap_visibilitymap_set(Relation rel, BlockNumber heapBlk, Buffer heapBuf,
 							  XLogRecPtr recptr, Buffer vmBuf, TransactionId cutoff_xid,
 							  uint8 flags);
-extern uint8 pg_tde_visibilitymap_get_status(Relation rel, BlockNumber heapBlk, Buffer *vmbuf);
-extern void pg_tde_visibilitymap_count(Relation rel, BlockNumber *all_visible, BlockNumber *all_frozen);
-extern BlockNumber pg_tde_visibilitymap_prepare_truncate(Relation rel,
+extern uint8 tdeheap_visibilitymap_get_status(Relation rel, BlockNumber heapBlk, Buffer *vmbuf);
+extern void tdeheap_visibilitymap_count(Relation rel, BlockNumber *all_visible, BlockNumber *all_frozen);
+extern BlockNumber tdeheap_visibilitymap_prepare_truncate(Relation rel,
 												  BlockNumber nheapblocks);
 
 #endif							/* PG_TDE_VISIBILITYMAP_H */

--- a/src/include/access/pg_tde_xlog.h
+++ b/src/include/access/pg_tde_xlog.h
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------------------
  *
- * pg_tde_xlog.h
+ * tdeheap_xlog.h
  *	  TDE XLog resource manager
  *
  *-------------------------------------------------------------------------
@@ -24,17 +24,17 @@
 
 /* TODO: ID has to be registedred and changed: https://wiki.postgresql.org/wiki/CustomWALResourceManagers */
 #define RM_TDERMGR_ID	RM_EXPERIMENTAL_ID
-#define RM_TDERMGR_NAME	"test_pg_tde_custom_rmgr"
+#define RM_TDERMGR_NAME	"test_tdeheap_custom_rmgr"
 
-extern void pg_tde_rmgr_redo(XLogReaderState *record);
-extern void pg_tde_rmgr_desc(StringInfo buf, XLogReaderState *record);
-extern const char *pg_tde_rmgr_identify(uint8 info);
+extern void tdeheap_rmgr_redo(XLogReaderState *record);
+extern void tdeheap_rmgr_desc(StringInfo buf, XLogReaderState *record);
+extern const char *tdeheap_rmgr_identify(uint8 info);
 
-static const RmgrData pg_tde_rmgr = {
+static const RmgrData tdeheap_rmgr = {
 	.rm_name = RM_TDERMGR_NAME,
-	.rm_redo = pg_tde_rmgr_redo,
-	.rm_desc = pg_tde_rmgr_desc,
-	.rm_identify = pg_tde_rmgr_identify
+	.rm_redo = tdeheap_rmgr_redo,
+	.rm_desc = tdeheap_rmgr_desc,
+	.rm_identify = tdeheap_rmgr_identify
 };
 
 #ifdef PERCONA_FORK
@@ -47,12 +47,12 @@ extern Size TDEXLogEncryptBuffSize(void);
 
 extern void TDEXLogShmemInit(void);
 
-extern ssize_t pg_tde_xlog_seg_read(int fd, void *buf, size_t count, off_t offset);
-extern ssize_t pg_tde_xlog_seg_write(int fd, const void *buf, size_t count, off_t offset);
+extern ssize_t tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset);
+extern ssize_t tdeheap_xlog_seg_write(int fd, const void *buf, size_t count, off_t offset);
 
 static const XLogSmgr tde_xlog_smgr = {
-	.seg_read = pg_tde_xlog_seg_read,
-	.seg_write = pg_tde_xlog_seg_write,
+	.seg_read = tdeheap_xlog_seg_read,
+	.seg_write = tdeheap_xlog_seg_write,
 };
 
 extern void TDEXLogSmgrInit(void);

--- a/src/include/access/pg_tdetoast.h
+++ b/src/include/access/pg_tdetoast.h
@@ -90,21 +90,21 @@
 	 VARHDRSZ)
 
 /* ----------
- * pg_tde_toast_insert_or_update -
+ * tdeheap_toast_insert_or_update -
  *
- *	Called by pg_tde_insert() and pg_tde_update().
+ *	Called by tdeheap_insert() and tdeheap_update().
  * ----------
  */
-extern HeapTuple pg_tde_toast_insert_or_update(Relation rel, HeapTuple newtup,
+extern HeapTuple tdeheap_toast_insert_or_update(Relation rel, HeapTuple newtup,
 											 HeapTuple oldtup, int options);
 
 /* ----------
- * pg_tde_toast_delete -
+ * tdeheap_toast_delete -
  *
- *	Called by pg_tde_delete().
+ *	Called by tdeheap_delete().
  * ----------
  */
-extern void pg_tde_toast_delete(Relation rel, HeapTuple oldtup,
+extern void tdeheap_toast_delete(Relation rel, HeapTuple oldtup,
 							  bool is_speculative);
 
 /* ----------
@@ -138,12 +138,12 @@ extern HeapTuple toast_build_flattened_tuple(TupleDesc tupleDesc,
 											 bool *isnull);
 
 /* ----------
- * pg_tde_fetch_toast_slice
+ * tdeheap_fetch_toast_slice
  *
  *	Fetch a slice from a toast value stored in a heap table.
  * ----------
  */
-extern void pg_tde_fetch_toast_slice(Relation toastrel, Oid valueid,
+extern void tdeheap_fetch_toast_slice(Relation toastrel, Oid valueid,
 								   int32 attrsize, int32 sliceoffset,
 								   int32 slicelength, struct varlena *result);
 

--- a/src/include/pg_tde_defines.h
+++ b/src/include/pg_tde_defines.h
@@ -24,19 +24,21 @@
 //#define TDE_FORK_DEBUG 1
 // #define TDE_XLOG_DEBUG 1
 
-#define pg_tde_fill_tuple heap_fill_tuple
-#define pg_tde_form_tuple heap_form_tuple
-#define pg_tde_deform_tuple heap_deform_tuple
-#define pg_tde_freetuple heap_freetuple
-#define pg_tde_compute_data_size heap_compute_data_size
+#define tdeheap_fill_tuple heap_fill_tuple
+#define tdeheap_form_tuple heap_form_tuple
+#define tdeheap_deform_tuple heap_deform_tuple
+#define tdeheap_freetuple heap_freetuple
+#define tdeheap_compute_data_size heap_compute_data_size
+#define tdeheap_getattr heap_getattr
+#define tdeheap_copytuple heap_copytuple
+#define tdeheap_getsysattr heap_getsysattr
 
-#define pgstat_count_pg_tde_scan pgstat_count_heap_scan
-#define pgstat_count_pg_tde_fetch pgstat_count_heap_fetch
-#define pgstat_count_pg_tde_getnext pgstat_count_heap_getnext
-#define pgstat_count_pg_tde_update pgstat_count_heap_update
-#define pgstat_count_pg_tde_delete pgstat_count_heap_delete
-#define pgstat_count_pg_tde_insert pgstat_count_heap_insert
-#define pg_tde_getattr heap_getattr
+#define pgstat_count_tdeheap_scan pgstat_count_heap_scan
+#define pgstat_count_tdeheap_fetch pgstat_count_heap_fetch
+#define pgstat_count_tdeheap_getnext pgstat_count_heap_getnext
+#define pgstat_count_tdeheap_update pgstat_count_heap_update
+#define pgstat_count_tdeheap_delete pgstat_count_heap_delete
+#define pgstat_count_tdeheap_insert pgstat_count_heap_insert
 
 #define TDE_PageAddItem(rel, oid, blkno, page, item, size, offsetNumber, overwrite, is_heap) \
 	PGTdePageAddItemExtended(rel, oid, blkno, page, item, size, offsetNumber, \

--- a/src/pg_tde.c
+++ b/src/pg_tde.c
@@ -118,7 +118,7 @@ _PG_init(void)
 	SetupTdeDDLHooks();
 	InstallFileKeyring();
 	InstallVaultV2Keyring();
-	RegisterCustomRmgr(RM_TDERMGR_ID, &pg_tde_rmgr);
+	RegisterCustomRmgr(RM_TDERMGR_ID, &tdeheap_rmgr);
 
 	RegisterStorageMgr();
 }


### PR DESCRIPTION
This commit consistently rename every "heap" occurence in function names/variables to tdeheap