### PR TITLE
Change access method to pg_tde_basic

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ FUNCTION pg_tde_set_principal_key (
 SELECT pg_tde_set_principal_key('my-principal-key','file');
 ```
 
-7. You are all set to create encrypted tables. For that, specify `USING pg_tde` in the `CREATE TABLE` statement.
+7. You are all set to create encrypted tables. For that, specify `USING pg_tde_basic` access method in the `CREATE TABLE` statement.
 **For example**:
 ```sql
 CREATE TABLE albums (
@@ -84,7 +84,7 @@ CREATE TABLE albums (
     artist_id INTEGER,
     title TEXT NOT NULL,
     released DATE NOT NULL
-) USING pg_tde;
+) USING pg_tde_basic;
 ```
 
 ## Build from source


### PR DESCRIPTION
Now that we do have the pg_tde and the pg_tde_basic access method, we need to change the default one to pg_tde_basic in the documentation, to avoid running into deployment issues.

Once our patched version is ready, we'll add more details around the pg_tde access method. 