### PR TITLE
Fix for PG-949: CREATE INDEX doesn't work with full encryption

### DIFF
--- a/src/pg_tde_event_capture.c
+++ b/src/pg_tde_event_capture.c
@@ -88,7 +88,6 @@ pg_tde_ddl_command_start_capture(PG_FUNCTION_ARGS)
 				/* set the global state */
 				tdeCurrentCreateEvent.encryptMode = true;
 			}
-			else
 			table_close(rel, lockmode);
 		}
 		else


### PR DESCRIPTION
This commit addresses a minor mistake in a previous cleanup PR that caused tables to not reliably close by event trigger function.