### PR TITLE
PG-959 Fix for an assert failure

### DIFF
--- a/src/access/pg_tde_tdemap.c
+++ b/src/access/pg_tde_tdemap.c
@@ -651,7 +651,7 @@ pg_tde_process_map_entry(const RelFileLocator *rlocator, char *db_map_path, off_
 	 */
 	if (should_delete == true && *offset > 0)
 	{
-		curr_pos = lseek(FileGetRawDesc(map_fd), *offset, SEEK_SET);
+		curr_pos = lseek(map_fd, *offset, SEEK_SET);
 
 		if (curr_pos == -1)
 		{


### PR DESCRIPTION
A while ago, we switched to using Linux fd syscalls instead of PostgreSQL's File Vfd, but we overlooked removing a call to FileGetRawDesc.