### PR TITLE
Fix smgr for PG17

### DIFF
--- a/src/smgr/pg_tde_smgr.c
+++ b/src/smgr/pg_tde_smgr.c
@@ -201,6 +201,7 @@ static const struct f_smgr tde_smgr = {
 	.smgr_nblocks = mdnblocks,
 	.smgr_truncate = mdtruncate,
 	.smgr_immedsync = mdimmedsync,
+	.smgr_registersync = mdregistersync,
 };
 
 void RegisterStorageMgr()


### PR DESCRIPTION
PG_17_STABLE added new method to "f_sgmr" interface. That method was lacking in our tde_smgr which led to SIGSEGV when core tried to use it.