### PR TITLE
PG-976: Fix for memory leaks

### DIFF
--- a/src/catalog/tde_global_space.c
+++ b/src/catalog/tde_global_space.c
@@ -181,6 +181,7 @@ init_keys(void)
 
 	cache_internal_key(rel_key_data, TDE_INTERNAL_XLOG_KEY);
 	pfree(rel_key_data);
+	pfree(enc_rel_key_data);
 	pfree(mkey);
 }
 

--- a/src/include/access/pg_tde_tdemap.h
+++ b/src/include/access/pg_tde_tdemap.h
@@ -27,19 +27,6 @@ typedef struct RelKeyData
     InternalKey     internal_key;
 } RelKeyData;
 
-/* Relation key cache.
- * 
- * TODO: For now it is just a linked list. Data can only be added w/o any
- * ability to remove or change it. Also consider usage of more efficient data
- * struct (hash map) in the shared memory(?) - currently allocated in the
- * TopMemoryContext of the process. 
- */
-typedef struct RelKey
-{
-    Oid     rel_id;
-    RelKeyData    *key;
-    struct RelKey *next;
-} RelKey;
 
 typedef struct XLogRelKey
 {
@@ -69,6 +56,6 @@ extern void pg_tde_set_db_file_paths(const RelFileLocator *rlocator, char *map_p
 
 const char * tde_sprint_key(InternalKey *k);
 
-extern void pg_tde_put_key_into_map(Oid rel_id, RelKeyData *key);
+extern RelKeyData *pg_tde_put_key_into_map(Oid rel_id, RelKeyData *key);
 
 #endif /*PG_TDE_MAP_H*/

--- a/src/include/smgr/pg_tde_smgr.h
+++ b/src/include/smgr/pg_tde_smgr.h
@@ -1,4 +1,15 @@
 
-#pragma once
+/*-------------------------------------------------------------------------
+ *
+ * pg_tde_smgr.h
+ * src/include/smgr/pg_tde_smgr.h
+ *
+ *-------------------------------------------------------------------------
+ */
 
-extern void RegisterStorageMgr();
+#ifndef PG_TDE_SMGR_H
+#define PG_TDE_SMGR_H
+
+extern void RegisterStorageMgr(void);
+
+#endif /* PG_TDE_SMGR_H */


### PR DESCRIPTION
This commit addresses several memory leaks primarily in the code related to obtaining the relation key and the storage manager (smgr). Additionally, fixes were made to the internal key cache maintained by each backend, as the keys were not properly added to the cache list.