### PR TITLE
Performance / memory usage fix: do not allocate memory in pg_tde_slot

### DIFF
--- a/src/include/access/pg_tde_slot.h
+++ b/src/include/access/pg_tde_slot.h
@@ -29,7 +29,8 @@ typedef struct TDEBufferHeapTupleTableSlot
 	 * such a case, since presumably base.tuple is pointing into the buffer.)
 	 */
 	Buffer		buffer;			/* tuple's buffer, or InvalidBuffer */
-    HeapTuple	decrypted_tuple;	/* decrypted tuple */
+	char		decrypted_buffer[BLCKSZ];
+	HeapTuple	decrypted_tuple;	/* decrypted tuple */
 } TDEBufferHeapTupleTableSlot;
 
 extern PGDLLIMPORT const TupleTableSlotOps TTSOpsTDEBufferHeapTuple;

--- a/src/include/access/pg_tde_slot.h
+++ b/src/include/access/pg_tde_slot.h
@@ -30,7 +30,6 @@ typedef struct TDEBufferHeapTupleTableSlot
 	 */
 	Buffer		buffer;			/* tuple's buffer, or InvalidBuffer */
 	char		decrypted_buffer[BLCKSZ];
-	HeapTuple	decrypted_tuple;	/* decrypted tuple */
 } TDEBufferHeapTupleTableSlot;
 
 extern PGDLLIMPORT const TupleTableSlotOps TTSOpsTDEBufferHeapTuple;
@@ -45,7 +44,5 @@ extern TupleTableSlot *PGTdeExecStoreBufferHeapTuple(Relation rel,
                          HeapTuple tuple,
 						 TupleTableSlot *slot,
 						 Buffer buffer);
-
-extern void TdeSlotForgetDecryptedTuple(TupleTableSlot *slot);
 
 #endif /* PG_TDE_SLOT_H */

--- a/src16/access/pg_tdeam.c
+++ b/src16/access/pg_tdeam.c
@@ -1159,7 +1159,6 @@ tdeheap_getnextslot(TableScanDesc sscan, ScanDirection direction, TupleTableSlot
 
 	if (scan->rs_ctup.t_data == NULL)
 	{
-		TdeSlotForgetDecryptedTuple(slot);
 		ExecClearTuple(slot);
 		return false;
 	}
@@ -1267,7 +1266,6 @@ tdeheap_getnextslot_tidrange(TableScanDesc sscan, ScanDirection direction,
 
 		if (scan->rs_ctup.t_data == NULL)
 		{
-			TdeSlotForgetDecryptedTuple(slot);
 			ExecClearTuple(slot);
 			return false;
 		}

--- a/src16/access/pg_tdeam_handler.c
+++ b/src16/access/pg_tdeam_handler.c
@@ -1185,7 +1185,6 @@ pg_tdeam_scan_analyze_next_tuple(TableScanDesc scan, TransactionId OldestXmin,
 	/* Now release the lock and pin on the page */
 	UnlockReleaseBuffer(hscan->rs_cbuf);
 	hscan->rs_cbuf = InvalidBuffer;
-	TdeSlotForgetDecryptedTuple(slot);
 	/* also prevent old slot contents from having pin on page */
 	ExecClearTuple(slot);
 
@@ -2457,16 +2456,6 @@ pg_tdeam_scan_sample_next_tuple(TableScanDesc scan, SampleScanState *scanstate,
 			 */
 			if (!pagemode)
 				LockBuffer(hscan->rs_cbuf, BUFFER_LOCK_UNLOCK);
-			/*
-			 * Hack:
-			 * The issue is that, The previous call that would have used the same
-			 * TupleTableSlot would have just deleted the memory context for the slot
-			 * and refrained from calling the clear slot function. So, the slot would
-			 * have the non NULL pointer to the decrypted tuple which is now invalid.
-			 * So, we need to explicitly clear the decrypted tuple pointer before
-			 * calling the clear slot function.
-			 */
-			TdeSlotForgetDecryptedTuple(slot);
 			ExecClearTuple(slot);
 			return false;
 		}

--- a/src17/access/pg_tdeam.c
+++ b/src17/access/pg_tdeam.c
@@ -1319,7 +1319,6 @@ tdeheap_getnextslot(TableScanDesc sscan, ScanDirection direction, TupleTableSlot
 
 	if (scan->rs_ctup.t_data == NULL)
 	{
-		TdeSlotForgetDecryptedTuple(slot);
 		ExecClearTuple(slot);
 		return false;
 	}
@@ -1427,7 +1426,6 @@ tdeheap_getnextslot_tidrange(TableScanDesc sscan, ScanDirection direction,
 
 		if (scan->rs_ctup.t_data == NULL)
 		{
-			TdeSlotForgetDecryptedTuple(slot);
 			ExecClearTuple(slot);
 			return false;
 		}

--- a/src17/access/pg_tdeam_handler.c
+++ b/src17/access/pg_tdeam_handler.c
@@ -1188,7 +1188,6 @@ pg_tdeam_scan_analyze_next_tuple(TableScanDesc scan, TransactionId OldestXmin,
 	/* Now release the lock and pin on the page */
 	UnlockReleaseBuffer(hscan->rs_cbuf);
 	hscan->rs_cbuf = InvalidBuffer;
-	TdeSlotForgetDecryptedTuple(slot);
 	/* also prevent old slot contents from having pin on page */
 	ExecClearTuple(slot);
 
@@ -2504,16 +2503,6 @@ pg_tdeam_scan_sample_next_tuple(TableScanDesc scan, SampleScanState *scanstate,
 			 */
 			if (!pagemode)
 				LockBuffer(hscan->rs_cbuf, BUFFER_LOCK_UNLOCK);
-			/*
-			 * Hack:
-			 * The issue is that, The previous call that would have used the same
-			 * TupleTableSlot would have just deleted the memory context for the slot
-			 * and refrained from calling the clear slot function. So, the slot would
-			 * have the non NULL pointer to the decrypted tuple which is now invalid.
-			 * So, we need to explicitly clear the decrypted tuple pointer before
-			 * calling the clear slot function.
-			 */
-			TdeSlotForgetDecryptedTuple(slot);
 			ExecClearTuple(slot);
 			return false;
 		}


### PR DESCRIPTION
Until now, for some reason we allocated memory for each decrypted tuple in pg_tde_slot, and only freed all that memory when the transaction ended. This caused two issues:

* palloc takes time, and the many small pallocs resulted in a significant performance drop in scans
* sequential scans could potentially allocate memory to the entire table, requiring way too much memory for large tables

This allocation is most likely a leftover from before we even used slots, and handled selects differently. With slots, we don't need them at all, as slots are not expected to handle multiple tuples at the same time, only the last one.

This commit removes the palloc completely, and instead adds a single BLCKSZ array to the slot structure, which can hold any size of decrypted tuple.

To be safe, it also disables the get tuple function, forcing the core code to use copy instead when needed.

This change results in:

1. no "memory spike" during sequential scans
2. ~1.55x overhead instead of ~2.2x

(The TODO in slot_copytuple will be addressed in a separate commit)