### PR TITLE
No need for a dedicated cache for globalspace internal key

### DIFF
--- a/src/access/pg_tde_xlog.c
+++ b/src/access/pg_tde_xlog.c
@@ -240,7 +240,7 @@ TDEXLogWriteEncryptedPages(int fd, const void *buf, size_t count, off_t offset)
 	size_t	data_size = 0;
 	XLogPageHeader	curr_page_hdr = &EncryptCurrentPageHrd;
 	XLogPageHeader	enc_buf_page;
-	RelKeyData		*key = TDEGetGlobalInternalKey(XLOG_TDE_OID);
+	RelKeyData		*key = GetRelationKey(GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID));
 	off_t	enc_off;
 	size_t	page_size = XLOG_BLCKSZ - offset % XLOG_BLCKSZ;
 	uint32	iv_ctr = 0;
@@ -327,7 +327,7 @@ tdeheap_xlog_seg_read(int fd, void *buf, size_t count, off_t offset)
 	char	iv_prefix[16] = {0,};
 	size_t	data_size = 0;
 	XLogPageHeader	curr_page_hdr = &DecryptCurrentPageHrd;
-	RelKeyData		*key = TDEGetGlobalInternalKey(XLOG_TDE_OID);
+	RelKeyData		*key = GetRelationKey(GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID));
 	size_t	page_size = XLOG_BLCKSZ - offset % XLOG_BLCKSZ;
 	off_t	dec_off;
 	uint32	iv_ctr = 0;

--- a/src/include/catalog/tde_global_space.h
+++ b/src/include/catalog/tde_global_space.h
@@ -31,6 +31,5 @@
 }
 
 extern void TDEInitGlobalKeys(void);
-extern RelKeyData * TDEGetGlobalInternalKey(Oid obj_id);
 
 #endif							/* TDE_GLOBAL_CATALOG_H */


### PR DESCRIPTION
Both caches existed in the same memory space so Globalspace's internal_keys_cache is redundant.

It also fixes PG-984 as it gets rid of pfree of the wrong object (`pfree(rel_key_data)`)