### PR TITLE
Fix a typo about tablespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ FUNCTION pg_tde_add_key_provider_file(
 SELECT pg_tde_add_key_provider_file('file','/tmp/pgkeyring');
 ```
 **Note: The `File` provided is intended for development and stores the keys unencrypted in the specified data file.**
+
 6. Set the principal key for the database using the `pg_tde_set_principal_key` function.
 ```sql
 FUNCTION pg_tde_set_principal_key (

--- a/pg_tde--1.0.sql
+++ b/pg_tde--1.0.sql
@@ -84,7 +84,7 @@ RETURNS SETOF record
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT VOLATILE;
 
--- Global Tblespace Key Provider Management
+-- Global Tablespace Key Provider Management
 CREATE OR REPLACE FUNCTION pg_tde_add_key_provider(PG_TDE_GLOBAL, provider_type VARCHAR(10), provider_name VARCHAR(128), options JSON)
 RETURNS INT
 AS $$


### PR DESCRIPTION
This commit also adds a blank line to improve the readability of the installation steps.