### PR TITLE
PG-978: Additional performance improvements for seq reads

### DIFF
--- a/src/access/pg_tde_slot.c
+++ b/src/access/pg_tde_slot.c
@@ -445,8 +445,8 @@ slot_copytuple(void* buffer, HeapTuple tuple)
 	newTuple->t_self = tuple->t_self;
 	newTuple->t_tableOid = tuple->t_tableOid;
 	newTuple->t_data = (HeapTupleHeader) ((char *) newTuple + HEAPTUPLESIZE);
-	// TODO: no need for this memcpy, don't decrypt in place instead!
-	memcpy((char *) newTuple->t_data, (char *) tuple->t_data, tuple->t_len);
+	// We don't copy the data, it will be copied by the decryption code
+	memcpy((char *) newTuple->t_data, (char *) tuple->t_data, tuple->t_data->t_hoff);
 	return newTuple;
 }
 


### PR DESCRIPTION
* Removed unneccessary memcpy call
* Cached relkeydata in the slot structure, so it doesn't have to be queried again and again

The improvement by these two changes is an additional few percentages.