### PR TITLE
Minor performance update

### DIFF
--- a/src/include/access/pg_tde_slot.h
+++ b/src/include/access/pg_tde_slot.h
@@ -11,9 +11,10 @@
 #define PG_TDE_SLOT_H
 
 
- #include "postgres.h"
- #include "executor/tuptable.h"
- #include "utils/relcache.h"
+#include "postgres.h"
+#include "executor/tuptable.h"
+#include "access/pg_tde_tdemap.h"
+#include "utils/relcache.h"
 
 /* heap tuple residing in a buffer */
 typedef struct TDEBufferHeapTupleTableSlot
@@ -30,6 +31,7 @@ typedef struct TDEBufferHeapTupleTableSlot
 	 */
 	Buffer		buffer;			/* tuple's buffer, or InvalidBuffer */
 	char		decrypted_buffer[BLCKSZ];
+	RelKeyData *cached_relation_key;
 } TDEBufferHeapTupleTableSlot;
 
 extern PGDLLIMPORT const TupleTableSlotOps TTSOpsTDEBufferHeapTuple;


### PR DESCRIPTION
Cache Relation Key in TupleTableSlot to Optimize Tuple Decryption. This commit cache the relation key directly in the TupleTableSlot to avoid repeated key lookups for each tuple decryption.