### PR TITLE
Align global space dbOid with the backend

### DIFF
--- a/src/include/catalog/tde_global_space.h
+++ b/src/include/catalog/tde_global_space.h
@@ -21,8 +21,9 @@
  * We take Oids of the sql operators, so there is no overlap with the "real"
  * catalog objects possible.
  */
-#define GLOBAL_DATA_TDE_OID	607 /* Global objects fake "db" */
 #define XLOG_TDE_OID        608
+
+#define GLOBAL_DATA_TDE_OID	InvalidOid
 
 #define GLOBAL_SPACE_RLOCATOR(_obj_oid) (RelFileLocator) { \
 	GLOBALTABLESPACE_OID, \


### PR DESCRIPTION
PG backend uses `InvalidOid` as the database Oid for global space rel locators. So should we.
Otherwise, it can (and does) cause issues like
https://perconadev.atlassian.net/browse/PG-1000
In that case, the backend creates a temporary relation in the "global space" leading to a dbOid mismatch.

Fixes PG-1000