### PR TITLE
PG-1009: remove leftover recursion checks

### DIFF
--- a/src/catalog/tde_principal_key.c
+++ b/src/catalog/tde_principal_key.c
@@ -769,17 +769,6 @@ GetPrincipalKey(Oid dbOid, Oid spcOid)
     LWLock *lock_files = tde_lwlock_mk_files();
     LWLock *lock_cache = tde_lwlock_mk_cache();
 
-	// TODO: This recursion counter is a dirty hack until the metadata is in the catalog
-	// As otherwise we would call GetPrincipalKey recursively and deadlock
-	static int recursion = 0;
-
-	if(recursion > 0)
-	{
-		return NULL;
-	}
-
-	recursion++;
-
 #ifndef FRONTEND
     /* We don't store global space key in cache */
     if (spcOid != GLOBALTABLESPACE_OID)
@@ -791,7 +780,6 @@ GetPrincipalKey(Oid dbOid, Oid spcOid)
 
     if (principalKey)
 	{
-		recursion--;
         return principalKey;
 	}
 #endif
@@ -814,7 +802,6 @@ GetPrincipalKey(Oid dbOid, Oid spcOid)
     {
         LWLockRelease(lock_cache);
         LWLockRelease(lock_files);
-		recursion--;
         return principalKey;
     }
 #endif
@@ -826,7 +813,6 @@ GetPrincipalKey(Oid dbOid, Oid spcOid)
         LWLockRelease(lock_cache);
         LWLockRelease(lock_files);
 
-		recursion--;
         return NULL;
     }
 
@@ -836,7 +822,6 @@ GetPrincipalKey(Oid dbOid, Oid spcOid)
         LWLockRelease(lock_cache);
         LWLockRelease(lock_files);
 
-        recursion--;
         return NULL;
     }
 
@@ -846,7 +831,6 @@ GetPrincipalKey(Oid dbOid, Oid spcOid)
         LWLockRelease(lock_cache);
         LWLockRelease(lock_files);
 
-		recursion--;
         return NULL;
     }
 
@@ -873,6 +857,5 @@ GetPrincipalKey(Oid dbOid, Oid spcOid)
     if (principalKeyInfo)
         pfree(principalKeyInfo);
 
-    recursion--;
     return principalKey;
 }

--- a/src/smgr/pg_tde_smgr.c
+++ b/src/smgr/pg_tde_smgr.c
@@ -13,9 +13,6 @@
 static RelKeyData*
 tde_smgr_get_key(SMgrRelation reln)
 {
-	// TODO: This recursion counter is a dirty hack until the metadata is in the catalog
-	// As otherwise we would call GetPrincipalKey recursively and deadlock
-	static int recursion = 0;
 	TdeCreateEvent *event;
 	RelKeyData *rkd;
 
@@ -25,16 +22,8 @@ tde_smgr_get_key(SMgrRelation reln)
 		return NULL;
 	}
 
-	if(recursion != 0) 
-	{
-		return NULL;
-	}
-
-	recursion++;
-
 	if(GetPrincipalKey(reln->smgr_rlocator.locator.dbOid, reln->smgr_rlocator.locator.spcOid)==NULL)
 	{
-		recursion--;
 		return NULL;
 	}
 
@@ -45,14 +34,12 @@ tde_smgr_get_key(SMgrRelation reln)
 
 	if(rkd != NULL)
 	{
-		recursion--;
 		return rkd;
 	}
 
 	// if this is a CREATE TABLE, we have to generate the key
 	if(event->encryptMode == true && event->eventType == TDE_TABLE_CREATE_EVENT)
 	{
-		recursion--;
 		return pg_tde_create_key_map_entry(&reln->smgr_rlocator.locator);
 	}
 	
@@ -61,11 +48,8 @@ tde_smgr_get_key(SMgrRelation reln)
 	{
 		// For now keep it simple and create separate key for indexes
 		// Later we might modify the map infrastructure to support the same keys
-		recursion--;
 		return pg_tde_create_key_map_entry(&reln->smgr_rlocator.locator);
 	}
-
-	recursion--;
 
 	return NULL;
 }


### PR DESCRIPTION
These were required when we stored encryption metadata in the catalog, but are no longer required.