### PR TITLE
PG-952: Handle non existent principal key in tde_heap

### DIFF
--- a/src/access/pg_tde_tdemap.c
+++ b/src/access/pg_tde_tdemap.c
@@ -149,7 +149,7 @@ pg_tde_create_key_map_entry(const RelFileLocator *newrlocator)
 	if (principal_key == NULL)
 	{
 		ereport(ERROR,
-				(errmsg("failed to retrieve principal key")));
+				(errmsg("failed to retrieve principal key. Create one using pg_tde_set_principal_key before using encrypted tables.")));
 
 		return NULL;
 	}
@@ -873,7 +873,7 @@ pg_tde_get_key_from_file(const RelFileLocator *rlocator)
 	{
 		LWLockRelease(lock_files);
 		ereport(ERROR,
-				(errmsg("failed to retrieve principal key")));
+				(errmsg("failed to retrieve principal key. Create one using pg_tde_set_principal_key before using encrypted tables.")));
 	}
 
 	/* Get the file paths */

--- a/src/catalog/tde_principal_key.c
+++ b/src/catalog/tde_principal_key.c
@@ -270,7 +270,7 @@ set_principal_key_with_keyring(const char *key_name, GenericKeyring *keyring,
             LWLockRelease(lock_files);
 
             ereport(ERROR,
-                    (errmsg("failed to retrieve principal key")));
+                    (errmsg("failed to retrieve principal key. Create one using pg_tde_set_principal_key before using encrypted tables.")));
         }
 
         principalKey->keyLength = keyInfo->data.len;


### PR DESCRIPTION
Previously when the database had no principal key, tde_heap simply igored it and created a table without encryption.

With this change, it reports an error instead.