### PR TITLE
Refactor internal/principal key LWLocks

### DIFF
--- a/src/access/pg_tde_xlog.c
+++ b/src/access/pg_tde_xlog.c
@@ -39,13 +39,17 @@ tdeheap_rmgr_redo(XLogReaderState *record)
 	{
 		XLogRelKey *xlrec = (XLogRelKey *) XLogRecGetData(record);
 
+		LWLockAcquire(tde_lwlock_enc_keys(), LW_EXCLUSIVE);
 		pg_tde_write_key_map_entry(&xlrec->rlocator, &xlrec->relKey, NULL);
+		LWLockRelease(tde_lwlock_enc_keys());
 	}
 	else if (info == XLOG_TDE_ADD_PRINCIPAL_KEY)
 	{
 		TDEPrincipalKeyInfo *mkey = (TDEPrincipalKeyInfo *) XLogRecGetData(record);
 
+		LWLockAcquire(tde_lwlock_enc_keys(), LW_EXCLUSIVE);
 		save_principal_key_info(mkey);
+		LWLockRelease(tde_lwlock_enc_keys());
 	}
 	else if (info == XLOG_TDE_EXTENSION_INSTALL_KEY)
 	{
@@ -64,7 +68,9 @@ tdeheap_rmgr_redo(XLogReaderState *record)
 	{
 		XLogPrincipalKeyRotate *xlrec = (XLogPrincipalKeyRotate *) XLogRecGetData(record);
 
+		LWLockAcquire(tde_lwlock_enc_keys(), LW_EXCLUSIVE);
 		xl_tde_perform_rotate_key(xlrec);
+		LWLockRelease(tde_lwlock_enc_keys());
 	}
 	else
 	{

--- a/src/include/access/pg_tde_tdemap.h
+++ b/src/include/access/pg_tde_tdemap.h
@@ -42,7 +42,7 @@ extern RelKeyData *GetRelationKey(RelFileLocator rel);
 
 extern void pg_tde_delete_tde_files(Oid dbOid, Oid spcOid);
 
-extern TDEPrincipalKeyInfo *pg_tde_get_principal_key(Oid dbOid, Oid spcOid);
+extern TDEPrincipalKeyInfo *pg_tde_get_principal_key_info(Oid dbOid, Oid spcOid);
 extern bool pg_tde_save_principal_key(TDEPrincipalKeyInfo *principal_key_info);
 extern bool pg_tde_perform_rotate_key(TDEPrincipalKey *principal_key, TDEPrincipalKey *new_principal_key);
 extern bool pg_tde_write_map_keydata_files(off_t map_size, char *m_file_data, off_t keydata_size, char *k_file_data);

--- a/src/include/catalog/tde_principal_key.h
+++ b/src/include/catalog/tde_principal_key.h
@@ -61,17 +61,15 @@ extern void InitializePrincipalKeyInfo(void);
 extern void cleanup_principal_key_info(Oid databaseId, Oid tablespaceId);
 
 #ifndef FRONTEND
-extern LWLock *tde_lwlock_mk_files(void);
-extern LWLock *tde_lwlock_mk_cache(void);
+extern LWLock *tde_lwlock_enc_keys(void);
+extern TDEPrincipalKey* GetPrincipalKey(Oid dbOid, Oid spcOid, LWLockMode lockMode);
 #else
-#define tde_lwlock_mk_files() NULL
-#define tde_lwlock_mk_cache() NULL
+extern TDEPrincipalKey* GetPrincipalKey(Oid dbOid, Oid spcOid, void *lockMode);
 #endif
 
 extern bool save_principal_key_info(TDEPrincipalKeyInfo *principalKeyInfo);
 
 extern Oid GetPrincipalKeyProviderId(void);
-extern TDEPrincipalKey* GetPrincipalKey(Oid dbOid, Oid spcOid);
 extern bool SetPrincipalKey(const char *key_name, const char *provider_name, bool ensure_new_key);
 extern bool RotatePrincipalKey(TDEPrincipalKey *current_key, const char *new_key_name, const char *new_provider_name, bool ensure_new_key);
 extern bool xl_tde_perform_rotate_key(XLogPrincipalKeyRotate *xlrec);

--- a/src/include/common/pg_tde_shmem.h
+++ b/src/include/common/pg_tde_shmem.h
@@ -18,8 +18,7 @@
 
 typedef enum
 {
-    TDE_LWLOCK_MK_CACHE,
-    TDE_LWLOCK_MK_FILES,
+    TDE_LWLOCK_ENC_KEY,
     TDE_LWLOCK_PI_FILES,
 
     /* Must be the last entry in the enum */

--- a/src/include/pg_tde_fe.h
+++ b/src/include/pg_tde_fe.h
@@ -76,7 +76,12 @@ static int	tde_fe_error_level = 0;
 
 #define LWLockAcquire(lock, mode) NULL
 #define LWLockRelease(lock_files) NULL
+#define LWLockHeldByMeInMode(lock, mode) NULL
 #define LWLock void
+#define LWLockMode void*
+#define LW_SHARED NULL
+#define LW_EXCLUSIVE NULL
+#define tde_lwlock_enc_keys() NULL
 
 #define BasicOpenFile(fileName, fileFlags) open(fileName, fileFlags, PG_FILE_MODE_OWNER)
 

--- a/src/smgr/pg_tde_smgr.c
+++ b/src/smgr/pg_tde_smgr.c
@@ -15,6 +15,7 @@ tde_smgr_get_key(SMgrRelation reln)
 {
 	TdeCreateEvent *event;
 	RelKeyData *rkd;
+	TDEPrincipalKey *pk;
 
 	if(IsCatalogRelationOid(reln->smgr_rlocator.locator.relNumber))
 	{
@@ -22,7 +23,10 @@ tde_smgr_get_key(SMgrRelation reln)
 		return NULL;
 	}
 
-	if(GetPrincipalKey(reln->smgr_rlocator.locator.dbOid, reln->smgr_rlocator.locator.spcOid)==NULL)
+	LWLockAcquire(tde_lwlock_enc_keys(), LW_SHARED);
+	pk = GetPrincipalKey(reln->smgr_rlocator.locator.dbOid, reln->smgr_rlocator.locator.spcOid, LW_SHARED);
+	LWLockRelease(tde_lwlock_enc_keys());
+	if(pk == NULL)
 	{
 		return NULL;
 	}


### PR DESCRIPTION
Before this commit, several flaws existed in the lock protection of the Internal and Principal keys. Such as double locking, insufficient locking while rotating the principal key and internal key retrieval from the disk. We also had two locks guarding the same actions, which in 90% of cases were locked and unlocked together. This commit tries to address all these issues.

For: https://perconadev.atlassian.net/browse/PG-858