### PR TITLE
Refactoring

### DIFF
--- a/src/catalog/tde_global_space.c
+++ b/src/catalog/tde_global_space.c
@@ -53,7 +53,7 @@ TDEInitGlobalKeys(const char *dir)
 #ifndef FRONTEND
 	char		db_map_path[MAXPGPATH] = {0};
 
-	pg_tde_set_db_file_paths(GLOBALTABLESPACE_OID, GLOBAL_DATA_TDE_OID, db_map_path, NULL);
+	pg_tde_set_db_file_paths(GLOBAL_DATA_TDE_OID, GLOBALTABLESPACE_OID,  db_map_path, NULL);
 	if (access(db_map_path, F_OK) == -1)
 	{
 		init_default_keyring();

--- a/src/catalog/tde_global_space.c
+++ b/src/catalog/tde_global_space.c
@@ -53,8 +53,7 @@ TDEInitGlobalKeys(const char *dir)
 #ifndef FRONTEND
 	char		db_map_path[MAXPGPATH] = {0};
 
-	pg_tde_set_db_file_paths(&GLOBAL_SPACE_RLOCATOR(XLOG_TDE_OID),
-							 db_map_path, NULL);
+	pg_tde_set_db_file_paths(GLOBALTABLESPACE_OID, GLOBAL_DATA_TDE_OID, db_map_path, NULL);
 	if (access(db_map_path, F_OK) == -1)
 	{
 		init_default_keyring();

--- a/src/include/access/pg_tde_tdemap.h
+++ b/src/include/access/pg_tde_tdemap.h
@@ -51,7 +51,7 @@ extern RelKeyData *tde_encrypt_rel_key(TDEPrincipalKey *principal_key, RelKeyDat
 extern RelKeyData *tde_decrypt_rel_key(TDEPrincipalKey *principal_key, RelKeyData *enc_rel_key_data, const RelFileLocator *rlocator);
 extern RelKeyData *pg_tde_get_key_from_file(const RelFileLocator *rlocator);
 
-extern void pg_tde_set_db_file_paths(const RelFileLocator *rlocator, char *map_path, char *keydata_path);
+extern void pg_tde_set_db_file_paths(Oid dbOid, Oid spcOid, char *map_path, char *keydata_path);
 
 const char * tde_sprint_key(InternalKey *k);
 


### PR DESCRIPTION
`pgindent` can't properly handle [compound literals](https://gcc.gnu.org/onlinedocs/gcc-4.3.2/gcc/Compound-Literals.html). It seems that we can easily refactor our code to make code fromatter work.