### PR TITLE
Fix vault dependency install for MacOS CI workflows

### DIFF
--- a/.github/workflows/postgresql-16-src-make-macos.yml
+++ b/.github/workflows/postgresql-16-src-make-macos.yml
@@ -8,7 +8,8 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          brew install vault gnu-sed
+          brew tap hashicorp/tap
+          brew install gnu-sed hashicorp/tap/vault
           sudo /usr/bin/perl -MCPAN -e 'install HTTP::Server::Simple'
 
       - name: Clone postgres repository

--- a/.github/workflows/postgresql-16-src-meson-macos.yml
+++ b/.github/workflows/postgresql-16-src-meson-macos.yml
@@ -8,7 +8,8 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          brew install meson vault gnu-sed
+          brew tap hashicorp/tap
+          brew install meson gnu-sed hashicorp/tap/vault
           sudo /usr/bin/perl -MCPAN -e 'install HTTP::Server::Simple'
 
       - name: Clone postgres repository


### PR DESCRIPTION
vault was removed from homebrew core repo: https://formulae.brew.sh/formula/vault

So we have to install it from dedicated `tap`